### PR TITLE
feat(document-search): allow to use local instance of unstructured

### DIFF
--- a/packages/ragbits-document-search/tests/integration/test_unstructured.py
+++ b/packages/ragbits-document-search/tests/integration/test_unstructured.py
@@ -38,20 +38,11 @@ async def test_document_processor_processes_text_document_with_unstructured_prov
     assert elements[0].content == "Name of Peppa's brother is George."
 
 
-@pytest.mark.parametrize(
-    "config",
-    [
-        {},
-        pytest.param(
-            {DocumentType.TXT: UnstructuredProvider(use_api=True)},
-            marks=pytest.mark.skipif(
-                env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
-                reason="Unstructured API environment variables not set",
-            ),
-        ),
-    ],
+@pytest.mark.skipif(
+    env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
+    reason="Unstructured API environment variables not set",
 )
-async def test_document_processor_processes_md_document_with_unstructured_provider(config):
+async def test_document_processor_processes_md_document_with_unstructured_provider():
     document_processor = DocumentProcessorRouter.from_config()
     document_meta = DocumentMeta.from_local_path(Path(__file__).parent / "test_file.md")
 

--- a/packages/ragbits-document-search/tests/integration/test_unstructured.py
+++ b/packages/ragbits-document-search/tests/integration/test_unstructured.py
@@ -14,12 +14,21 @@ from ragbits.document_search.ingestion.providers.unstructured import (
 from ..helpers import env_vars_not_set
 
 
-@pytest.mark.skipif(
-    env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
-    reason="Unstructured API environment variables not set",
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        pytest.param(
+            {DocumentType.TXT: UnstructuredProvider(use_api=True)},
+            marks=pytest.mark.skipif(
+                env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
+                reason="Unstructured API environment variables not set",
+            ),
+        ),
+    ],
 )
-async def test_document_processor_processes_text_document_with_unstructured_provider():
-    document_processor = DocumentProcessorRouter.from_config()
+async def test_document_processor_processes_text_document_with_unstructured_provider(config):
+    document_processor = DocumentProcessorRouter.from_config(config)
     document_meta = DocumentMeta.create_text_document_from_literal("Name of Peppa's brother is George.")
 
     elements = await document_processor.get_provider(document_meta).process(document_meta)
@@ -29,11 +38,20 @@ async def test_document_processor_processes_text_document_with_unstructured_prov
     assert elements[0].content == "Name of Peppa's brother is George."
 
 
-@pytest.mark.skipif(
-    env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
-    reason="Unstructured API environment variables not set",
+@pytest.mark.parametrize(
+    "config",
+    [
+        {},
+        pytest.param(
+            {DocumentType.TXT: UnstructuredProvider(use_api=True)},
+            marks=pytest.mark.skipif(
+                env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
+                reason="Unstructured API environment variables not set",
+            ),
+        ),
+    ],
 )
-async def test_document_processor_processes_md_document_with_unstructured_provider():
+async def test_document_processor_processes_md_document_with_unstructured_provider(config):
     document_processor = DocumentProcessorRouter.from_config()
     document_meta = DocumentMeta.from_local_path(Path(__file__).parent / "test_file.md")
 
@@ -43,13 +61,22 @@ async def test_document_processor_processes_md_document_with_unstructured_provid
     assert elements[0].content == "Ragbits\n\nRepository for internal experiment with our upcoming LLM framework."
 
 
-@pytest.mark.skipif(
-    env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
-    reason="Unstructured API environment variables not set",
+@pytest.mark.parametrize(
+    "use_api",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
+                reason="Unstructured API environment variables not set",
+            ),
+        ),
+    ],
 )
-async def test_unstructured_provider_document_with_default_partition_kwargs():
+async def test_unstructured_provider_document_with_default_partition_kwargs(use_api):
     document_meta = DocumentMeta.create_text_document_from_literal("Name of Peppa's brother is George.")
-    unstructured_provider = UnstructuredProvider()
+    unstructured_provider = UnstructuredProvider(use_api=use_api)
     elements = await unstructured_provider.process(document_meta)
 
     assert unstructured_provider.partition_kwargs == DEFAULT_PARTITION_KWARGS
@@ -57,14 +84,23 @@ async def test_unstructured_provider_document_with_default_partition_kwargs():
     assert elements[0].content == "Name of Peppa's brother is George."
 
 
-@pytest.mark.skipif(
-    env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
-    reason="Unstructured API environment variables not set",
+@pytest.mark.parametrize(
+    "use_api",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                env_vars_not_set([UNSTRUCTURED_SERVER_URL_ENV, UNSTRUCTURED_API_KEY_ENV]),
+                reason="Unstructured API environment variables not set",
+            ),
+        ),
+    ],
 )
-async def test_unstructured_provider_document_with_custom_partition_kwargs():
+async def test_unstructured_provider_document_with_custom_partition_kwargs(use_api):
     document_meta = DocumentMeta.create_text_document_from_literal("Name of Peppa's brother is George.")
     partition_kwargs = {"languages": ["pl"], "strategy": "fast"}
-    unstructured_provider = UnstructuredProvider(partition_kwargs=partition_kwargs)
+    unstructured_provider = UnstructuredProvider(use_api=use_api, partition_kwargs=partition_kwargs)
     elements = await unstructured_provider.process(document_meta)
 
     assert unstructured_provider.partition_kwargs == partition_kwargs

--- a/packages/ragbits-document-search/tests/unit/test_providers.py
+++ b/packages/ragbits-document-search/tests/unit/test_providers.py
@@ -23,7 +23,7 @@ def test_unsupported_provider_validates_supported_document_types_fails():
 @patch.dict(os.environ, {}, clear=True)
 async def test_unstructured_provider_raises_value_error_when_api_key_not_set():
     with pytest.raises(ValueError) as err:
-        await UnstructuredProvider().process(
+        await UnstructuredProvider(use_api=True).process(
             DocumentMeta.create_text_document_from_literal("Name of Peppa's brother is George.")
         )
 
@@ -33,7 +33,7 @@ async def test_unstructured_provider_raises_value_error_when_api_key_not_set():
 @patch.dict(os.environ, {}, clear=True)
 async def test_unstructured_provider_raises_value_error_when_server_url_not_set():
     with pytest.raises(ValueError) as err:
-        await UnstructuredProvider(api_key="api_key").process(
+        await UnstructuredProvider(api_key="api_key", use_api=True).process(
             DocumentMeta.create_text_document_from_literal("Name of Peppa's brother is George.")
         )
 


### PR DESCRIPTION
I added the local unstructured as default (I think running samples for users shouldn't force them to provide api key or server endpoints which may be seen as a potential blocker). To run with api one needs to create `DocumentSearch` with argument: `document_processor_router=DocumentProcessorRouter.from_config({DocumentType.TXT: UnstructuredProvider(use_api=True)})`