### PR TITLE
chore: update uv version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v2
         with:
-          version: "0.4.10"
+          version: "0.4.20"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v2
         with:
-          version: "0.4.10"
+          version: "0.4.20"
       - name: Cache Dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Update uv to version 0.4.20.

This update is required by the documentation deployment script, which uses the `uv sync --only-dev` option introduced in version 0.4.11