### PR TITLE
chore: release ragbits v0.2.0

### DIFF
--- a/packages/ragbits-cli/CHANGELOG.md
+++ b/packages/ragbits-cli/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.2.0 (2024-10-23)
+
+### Changed
+
+- Improved performance by lazy-loading the modules (#111 #113 #120)
+- ragbits-core updated to version v0.2.0
+
 ## 0.1.0 (2024-10-08)
 
 ### Added

--- a/packages/ragbits-cli/pyproject.toml
+++ b/packages/ragbits-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragbits-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "A CLI application for ragbits - building blocks for rapid development of GenAI applications"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,10 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-    "typer>=0.12.5",
-    "ragbits-core==0.1.0"
-]
+dependencies = ["typer>=0.12.5", "ragbits-core==0.2.0"]
 
 [project.scripts]
 ragbits = "ragbits.cli:main"

--- a/packages/ragbits-core/CHANGELOG.md
+++ b/packages/ragbits-core/CHANGELOG.md
@@ -2,10 +2,23 @@
 
 ## Unreleased
 
-## 0.1.0 (2024-10-08)
+## 0.2.0 (2024-10-23)
 
 ### Added
 
+- Project README.md (#103).
+- Listing entries API for VectorStores (#138).
+- Overrides for prompt discovery configurable in `pyproject.toml` file (#101).
+- Default LLM factory configurable in `pyproject.toml` file (#101).
+
+### Changed
+
+- Fixed bug in chromadb while returning multiple records (#117).
+- Fixed bug in prompt rendering for some pydantic models (#137).
+
+## 0.1.0 (2024-10-08)
+
+### Added
 
 - Initial release of the package.
 - Introduce core components: Prompts, LLMs, Embeddings and VectorStores.

--- a/packages/ragbits-core/pyproject.toml
+++ b/packages/ragbits-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragbits-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Building blocks for rapid development of GenAI applications"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/ragbits-document-search/CHANGELOG.md
+++ b/packages/ragbits-document-search/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 0.2.0 (2024-10-23)
+
+### Added
+
+- Creation of DocumentSearch instances from config (#62).
+- Automatic detection of document type (#99).
+- LLM-based query rephrasing (#115).
+- Batch ingestion from sources (#112).
+- Add support to image formats (#121).
+- Add HuggingFace sources (#106).
+
+### Changed
+
+- ragbits-core updated to version v0.2.0
 
 ## 0.1.0 (2024-10-08)
 

--- a/packages/ragbits-document-search/pyproject.toml
+++ b/packages/ragbits-document-search/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragbits-document-search"
-version = "0.1.0"
+version = "0.2.0"
 description = "Document Search module for Ragbits"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,12 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-    "unstructured>=0.15.13",
-    "unstructured-client>=0.26.0",
-    "pdf2image>=1.17.0",
-    "ragbits-core==0.1.0"
-]
+dependencies = ["unstructured>=0.15.13", "unstructured-client>=0.26.0", "pdf2image>=1.17.0", "ragbits-core==0.2.0"]
 
 [project.optional-dependencies]
 gcs = [

--- a/packages/ragbits-evaluate/CHANGELOG.md
+++ b/packages/ragbits-evaluate/CHANGELOG.md
@@ -1,0 +1,13 @@
+# CHANGELOG
+
+## Unreleased
+
+## 0.2.0 (2024-10-23)
+
+- Initial release of the package.
+- Evaluation pipeline framework with capability to define evaluators & metrics.
+- Evaluation pipeline for `ragbits-document-search`.
+
+### Changed
+
+- ragbits-core updated to version v0.2.0

--- a/packages/ragbits-evaluate/pyproject.toml
+++ b/packages/ragbits-evaluate/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragbits-evaluate"
-version = "0.1.0"
+version = "0.2.0"
 description = "Evaluation module for Ragbits components"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,10 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = [
-    "hydra-core~=1.3.2",
-    "neptune~=1.12.0",
-]
+dependencies = ["hydra-core~=1.3.2", "neptune~=1.12.0", "ragbits-core==0.2.0"]
 
 [project.optional-dependencies]
 relari = [

--- a/packages/ragbits/CHANGELOG.md
+++ b/packages/ragbits/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+## 0.2.0 (2024-10-23)
+
+### Added
+
+- ragbits-evaluate v0.2.0:
+  - Initial release of the package (#91).
+  - Evaluation pipeline framework with capability to define evaluators & metrics.
+  - Evaluation pipeline for `ragbits-document-search`.
+
+### Changed
+
+- ragbits-cli updated to version v0.2.0
+  - Improved performance by lazy-loading the modules (#111 #113 #120)
+- ragbits-document-search updated to version v0.2.0
+  - Creation of DocumentSearch instances from config (#62).
+  - Automatic detection of document type (#99).
+  - LLM-based query rephrasing (#115).
+  - Batch ingestion from sources (#112).
+  - Support to image formats (#121).
+  - HuggingFace sources (#106).
+- ragbits-core updated to version v0.2.0
+  - Project README.md (#103).
+  - Listing entries API for VectorStores (#138).
+  - Overrides for prompt discovery configurable in `pyproject.toml` file (#101).
+  - Default LLM factory configurable in `pyproject.toml` file (#101).
+  - Fixed bug in chromadb while returning multiple records (#117).
+  - Fixed bug in prompt rendering for some pydantic models (#137).
+
 ## 0.1.0 (2024-10-08)
 
 ### Added

--- a/packages/ragbits/pyproject.toml
+++ b/packages/ragbits/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ragbits"
-version = "0.1.0"
+version = "0.2.0"
 description = "Building blocks for rapid development of GenAI applications"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -31,9 +31,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "ragbits-document-search==0.1.0",
-    "ragbits-cli==0.1.0",
-    "ragbits-core==0.1.0"
+    "ragbits-document-search==0.2.0",
+    "ragbits-cli==0.2.0",
+    "ragbits-evaluate==0.2.0",
+    "ragbits-core==0.2.0"
 ]
 
 [build-system]


### PR DESCRIPTION
## 0.2.0 (2024-10-23)

### Added

- ragbits-evaluate v0.2.0:
  - Initial release of the package (#91).
  - Evaluation pipeline framework with capability to define evaluators & metrics.
  - Evaluation pipeline for `ragbits-document-search`.

### Changed

- ragbits-cli updated to version v0.2.0
  - Improved performance by lazy-loading the modules (#111 #113 #120)
- ragbits-document-search updated to version v0.2.0
  - Creation of DocumentSearch instances from config (#62).
  - Automatic detection of document type (#99).
  - LLM-based query rephrasing (#115).
  - Batch ingestion from sources (#112).
  - Support to image formats (#121).
  - HuggingFace sources (#106).
- ragbits-core updated to version v0.2.0
  - Project README.md (#103).
  - Listing entries API for VectorStores (#138).
  - Overrides for prompt discovery configurable in `pyproject.toml` file (#101).
  - Default LLM factory configurable in `pyproject.toml` file (#101).
  - Fixed bug in chromadb while returning multiple records (#117).
  - Fixed bug in prompt rendering for some pydantic models (#137).