### PR TITLE
chore: install extras from ragbits index package

### DIFF
--- a/packages/ragbits/pyproject.toml
+++ b/packages/ragbits/pyproject.toml
@@ -39,6 +39,43 @@ dependencies = [
     "ragbits-core==0.3.0"
 ]
 
+[project.optional-dependencies]
+chroma = [
+    "chromadb~=0.4.24",
+]
+huggingface = [
+    "datasets~=3.0.1",
+]
+gcs = [
+    "gcloud-aio-storage~=9.3.0"
+]
+lab = [
+    "gradio~=4.44.0",
+]
+litellm = [
+    "litellm~=1.46.0",
+]
+local = [
+    "torch~=2.2.1",
+    "transformers~=4.44.2",
+    "numpy~=1.26.0"
+]
+openai = [
+    "openai~=1.51.0",
+]
+otel = [
+    "opentelemetry-api~=1.27.0",
+]
+promptfoo = [
+    "PyYAML~=6.0.2",
+]
+qdrant = [
+    "qdrant-client~=1.12.1",
+]
+relari = [
+    "continuous-eval~=0.3.12",
+]
+
 [build-system]
 requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"

--- a/scripts/update_ragbits_package.py
+++ b/scripts/update_ragbits_package.py
@@ -186,13 +186,15 @@ def _update_ragbits_extras(packages: list[str]) -> None:
 
     extras = {}
     for pkg in subpackages:
-        pkg_pyproject_path = PACKAGES_DIR / pkg / 'pyproject.toml'
+        pkg_pyproject_path = PACKAGES_DIR / pkg / "pyproject.toml"
         pkg_pyproject = tomlkit.parse(pkg_pyproject_path.read_text())
 
-        if 'optional-dependencies' in pkg_pyproject['project']:
-            for extra, deps in pkg_pyproject['project']['optional-dependencies'].items():
+        if "optional-dependencies" in pkg_pyproject["project"]:
+            for extra, deps in pkg_pyproject["project"]["optional-dependencies"].items():
                 if extra in extras and extras[extra] != deps:
-                    raise Exception(f"Duplicate extras found: '{extra}' exists in multiple packages that have different dependencies.")
+                    raise Exception(
+                        f"Duplicate extras found: '{extra}' exists in multiple packages that have different dependencies."
+                    )
                 extras[extra] = deps
 
     extras = {extra: deps for extra, deps in sorted(extras.items())}
@@ -201,7 +203,7 @@ def _update_ragbits_extras(packages: list[str]) -> None:
     ragbits_pyproject_data = tomlkit.parse(ragbits_pyproject_path.read_text())
 
     for extra, deps in extras.items():
-        ragbits_pyproject_data['project']['optional-dependencies'][extra] = deps
+        ragbits_pyproject_data["project"]["optional-dependencies"][extra] = deps
 
     ragbits_pyproject_path.write_text(tomlkit.dumps(ragbits_pyproject_data))
 

--- a/scripts/update_ragbits_package.py
+++ b/scripts/update_ragbits_package.py
@@ -251,6 +251,7 @@ def run(pkg_name: str | None = typer.Argument(None), update_type: str | None = t
             is_continue = True
 
         if is_continue:
+            _update_ragbits_extras(packages)
             version, new_version = _update_pkg_version(pkg_name, update_type=casted_update_type)
             casted_update_type = _check_update_type(version, new_version)
 

--- a/scripts/update_ragbits_package.py
+++ b/scripts/update_ragbits_package.py
@@ -193,11 +193,11 @@ def _update_ragbits_extras(packages: list[str]) -> None:
             for extra, deps in pkg_pyproject["project"]["optional-dependencies"].items():
                 if extra in extras and extras[extra] != deps:
                     raise Exception(
-                        f"Duplicate extras found: '{extra}' exists in multiple packages that have different dependencies."
+                        f"Duplicate extras: '{extra}' exists in multiple packages with different dependencies."
                     )
                 extras[extra] = deps
 
-    extras = {extra: deps for extra, deps in sorted(extras.items())}
+    extras = dict(sorted(extras.items()))
 
     ragbits_pyproject_path = PACKAGES_DIR / "ragbits" / "pyproject.toml"
     ragbits_pyproject_data = tomlkit.parse(ragbits_pyproject_path.read_text())


### PR DESCRIPTION
## Description

- Extras from subpackages are now included in the `ragbits` package.
- Modified `scripts/update_ragbits_package.py` to sync extras versions in `ragbits` with those declared in subpackages.