### PR TITLE
chore: automated release process

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,4 +1,4 @@
-name: Semantic Release
+name: Prepare Release
 
 on:
   workflow_dispatch:
@@ -17,10 +17,7 @@ on:
         required: true
         type: choice
         options:
-          - "ragbits"
-          - "ragbits-cli"
           - "ragbits-core"
-          - "ragbits-document-search"
 
 jobs:
   release:
@@ -41,12 +38,6 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: Create release branch
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b release/${{ github.event.inputs.packageName }}-$(date +%Y-%m-%d)
-
       - name: Update packages
         id: packages_update
         run: |
@@ -54,6 +45,12 @@ jobs:
           uv run scripts/update_ragbits_package.py ${{ github.event.inputs.packageName }} ${{ github.event.inputs.updateType }}
           echo new_version=`grep version packages/${{ github.event.inputs.packageName }}/pyproject.toml | cut -d \" -f2` >> $GITHUB_OUTPUT
           uv sync
+
+      - name: Create release branch
+        run: |
+          git config user.name "ds-ragbits-robot"
+          git config user.email "ds-ragbits-robot@users.noreply.github.com"
+          git checkout -b release/${{ github.event.inputs.packageName }}-v${{ steps.packages_update.outputs.new_version }}
 
       - name: Create PR with updated packages
         run: |

--- a/.github/workflows/push_release.yml
+++ b/.github/workflows/push_release.yml
@@ -1,0 +1,51 @@
+name: Push Release
+
+on:
+  pull_request_target:
+    types:
+      - closed
+jobs:
+  publish_release:
+    if: startsWith(github.head_ref, 'release/') && github.event.pull_request.merged == true && github.event.pull_request.user.login == 'ds-ragbits-robot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          version: "0.4.10"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Get tag name
+        id: tag_name
+        run: |
+          TAG_NAME=$(echo "${{ github.event.pull_request.head.ref }}" | sed 's/.*-//')
+          echo "new_tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create release notes
+        run: |
+          uv run scripts/create_release_notes.py
+
+      - name: Publish release
+        run: |
+          gh release create ${{ steps.tag_name.outputs.new_tag }} \
+            --title "${{ steps.tag_name.outputs.new_tag }}" \
+            --notes-file RELEASE_NOTES.md
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Build packages
+        run: |
+          for dir in packages/*/; do uv build "$dir" --out-dir dist; done
+
+      - name: Publish packages
+        run: |
+          uv tool run twine upload dist/*
+        env:
+            TWINE_USERNAME: __token__
+            TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/scripts/create_release_notes.py
+++ b/scripts/create_release_notes.py
@@ -1,0 +1,70 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+# ]
+# ///
+# To run this script and create a new package, run the following command:
+#
+#   uv run scripts/create_ragbits_package.py
+#
+import re
+from pathlib import Path
+
+
+def extract_latest_version_content(changelog_content: str) -> str | None:
+    """
+    Extract the content of the latest version section from the CHANGELOG.md file.
+
+    Args:
+        changelog_content: Content of the CHANGELOG.md file.
+
+    Returns:
+        Content of the latest version section.
+    """
+    # Find all version sections
+    version_pattern = r"## (\d+\.\d+\.\d+.*?)(?=\n## |\Z)"
+    versions = re.finditer(version_pattern, changelog_content, re.DOTALL)
+
+    # Get the first (latest) version section
+    try:
+        latest_version = next(versions)
+        return latest_version.group(1).strip().replace("### ", "## ")
+    except StopIteration:
+        return None
+
+
+def create_release_notes(package: str = "ragbits") -> None:
+    """
+    Create a RELEASE_NOTES.md file for the specified package.
+
+    Args:
+        package: Package name.
+    """
+    try:
+        changelog_file = Path(__file__).parent.parent / "packages" / package / "CHANGELOG.md"
+        changelog_content = changelog_file.read_text()
+    except FileNotFoundError:
+        print("Error: CHANGELOG.md file not found!")
+        return
+
+    # Extract the latest version content
+    latest_version_content = extract_latest_version_content(changelog_content)
+
+    if not latest_version_content:
+        print("Error: No version information found in CHANGELOG.md!")
+        return
+
+    # Create RELEASE_NOTES.md content
+    release_notes_content = f"# {latest_version_content}"
+
+    # Write to RELEASE_NOTES.md
+    try:
+        with open("RELEASE_NOTES.md", "w", encoding="utf-8") as file:
+            file.write(release_notes_content)
+        print("Successfully created RELEASE_NOTES.md")
+    except Exception as e:
+        print(f"Error writing to RELEASE_NOTES.md: {str(e)}")
+
+
+if __name__ == "__main__":
+    create_release_notes()


### PR DESCRIPTION
New 2-step approach to automatic release:

* At first we use manually triggered "Prepare release" action which creates a new PR with version bump + changelogs
* After merging "release PR" we have automatic release publication on github + pypi