### PR TITLE
chore: stricter mkdocs validation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,3 +139,8 @@ extra:
       link: https://medium.com/deepsense-ai
     - icon: fontawesome/solid/globe
       link: https://deepsense.ai
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn


### PR DESCRIPTION
Before some problems in mkdocs that should be reported as warnings were reported as "info" instead and as such not reported during our CI process.

This commit uses the configuration that mkdocs documentation describes as "recommended settings for most sites": https://www.mkdocs.org/user-guide/configuration/#validation