### PR TITLE
fix: Rename HttpSource to WebSource

### DIFF
--- a/packages/ragbits-document-search/CHANGELOG.md
+++ b/packages/ragbits-document-search/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- BREAKING CHANGE: Renamed HttpSource to WebSource (#420)
+- Better error distinction for WebSource (#421)
+
 ## 0.10.0 (2025-03-17)
 
 ### Changed

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
@@ -25,3 +25,12 @@ class SourceNotFoundError(SourceError):
     def __init__(self, source_id: str) -> None:
         super().__init__(f"Source with ID {source_id} not found.")
         self.source_id = source_id
+
+
+class WebDownloadError(SourceError):
+    """
+    Raised when an error occurs during the download of a file from an Web source.
+    """
+
+    def __init__(self, uri: str, code: int):
+        super().__init__(f"Download of {uri} failed with code {code}.")

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/sources/__init__.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/sources/__init__.py
@@ -2,16 +2,16 @@ from ragbits.document_search.documents.sources.base import Source  # noqa: I001
 from ragbits.document_search.documents.sources.azure import AzureBlobStorageSource
 from ragbits.document_search.documents.sources.gcs import GCSSource
 from ragbits.document_search.documents.sources.hf import HuggingFaceSource
-from ragbits.document_search.documents.sources.http import HttpSource
 from ragbits.document_search.documents.sources.local import LocalFileSource
 from ragbits.document_search.documents.sources.s3 import S3Source
+from ragbits.document_search.documents.sources.web import WebSource
 
 __all__ = [
     "AzureBlobStorageSource",
     "GCSSource",
-    "HttpSource",
     "HuggingFaceSource",
     "LocalFileSource",
     "S3Source",
     "Source",
+    "WebSource",
 ]

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/sources/web.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/sources/web.py
@@ -9,41 +9,42 @@ with suppress(ImportError):
     import aiohttp
 
 from ragbits.core.utils.decorators import requires_dependencies
-from ragbits.document_search.documents.exceptions import SourceNotFoundError
+from ragbits.document_search.documents.exceptions import SourceNotFoundError, WebDownloadError
 from ragbits.document_search.documents.sources import Source
 from ragbits.document_search.documents.sources.base import get_local_storage_dir
 
 
-class HttpSource(Source):
+class WebSource(Source):
     """
-    An object representing an HTTP dataset source.
+    An object representing a Web dataset source.
     """
 
-    url: str
+    uri: str
     protocol: ClassVar[str] = "https"
 
     @property
     def id(self) -> str:
         """
-        Get the source ID, which is the full url to the file.
+        Get the source ID, which is an unique identifier of the object.
         """
-        return f"https:{self.url}"
+        return f"web:{self.uri}"
 
     @requires_dependencies(["aiohttp"])
     async def fetch(self) -> Path:
         """
-        Download a file available in the given url.
+        Download a file available in the given uri.
 
         Returns:
             Path: The local path to the downloaded file.
 
         Raises:
-            SourceNotFoundError: If the URL is invalid.
+            WebDownloadError: If the download failed.
+            SourceNotFoundError: If the URI is invalid.
         """
-        parsed_url = urlparse(self.url)
-        url_path, file_name = ("/" + parsed_url.netloc + parsed_url.path).rsplit("/", 1)
+        parsed_uri = urlparse(self.uri)
+        url_path, file_name = ("/" + parsed_uri.netloc + parsed_uri.path).rsplit("/", 1)
         normalized_url_path = re.sub(r"\W", "_", url_path) + file_name
-        domain_name = parsed_url.netloc
+        domain_name = parsed_uri.netloc
 
         local_dir = get_local_storage_dir()
         container_local_dir = local_dir / domain_name
@@ -51,42 +52,42 @@ class HttpSource(Source):
         path = container_local_dir / normalized_url_path
 
         try:
-            async with aiohttp.ClientSession() as session, session.get(self.url) as response:
+            async with aiohttp.ClientSession() as session, session.get(self.uri) as response:
                 if response.ok:
                     with open(path, "wb") as f:
                         async for chunk in response.content.iter_chunked(1024):
                             f.write(chunk)
                 else:
-                    raise SourceNotFoundError(self.id)
+                    raise WebDownloadError(uri=self.uri, code=response.status)
         except (aiohttp.ClientError, IsADirectoryError) as e:
             raise SourceNotFoundError(self.id) from e
 
         return path
 
     @classmethod
-    async def list_sources(cls, url: str) -> Sequence["HttpSource"]:
+    async def list_sources(cls, uri: str) -> Sequence["WebSource"]:
         """
-        List the file under the given URL.
+        List the file under the given URI.
 
         Arguments:
-            url: The URL to the file.
+            uri: The URI to the file.
 
         Returns:
-            Sequence: The Sequence with HTTP source.
+            Sequence: The Sequence with Web source.
         """
-        return [cls(url=url)]
+        return [cls(uri=uri)]
 
     @classmethod
-    async def from_uri(cls, url: str) -> Sequence["HttpSource"]:
+    async def from_uri(cls, uri: str) -> Sequence["WebSource"]:
         """
-        Create HttpSource instances from a URI path.
-        The supported url format is:
+        Create WebSource instances from a URI path.
+        The supported uri format is:
         <protocol>://<domain>/<path>/<filename>.<file_extension>
 
         Args:
-            url: The URI path.
+            uri: The URI path.
 
         Returns:
-            A sequence containing a HttpSource instance.
+            A sequence containing a WebSource instance.
         """
-        return [cls(url=url)]
+        return [cls(uri=uri)]

--- a/packages/ragbits-document-search/tests/unit/test_web_source.py
+++ b/packages/ragbits-document-search/tests/unit/test_web_source.py
@@ -1,12 +1,12 @@
 from sympy.testing import pytest
 
 from ragbits.document_search.documents.exceptions import SourceNotFoundError
-from ragbits.document_search.documents.sources.http import HttpSource
+from ragbits.document_search.documents.sources.web import WebSource
 
 
 def test_id():
-    source = HttpSource(url="http://example.com/file.pdf")
-    expected_id = "https:http://example.com/file.pdf"
+    source = WebSource(uri="http://example.com/file.pdf")
+    expected_id = "web:http://example.com/file.pdf"
     assert source.id == expected_id
 
 
@@ -22,18 +22,18 @@ async def test_from_uri_one_file():
     ]
 
     for uri in file_uris:
-        result = await HttpSource.from_uri(uri)
-        assert result[0] == HttpSource(url=uri)
+        result = await WebSource.from_uri(uri)
+        assert result[0] == WebSource(uri=uri)
 
 
-async def test_invalid_url_raises_exception():
+async def test_invalid_uri_raises_exception():
     wrong_uris = [
         "some string",
-        "https://www.url with spaces.com/path/to/file",
+        "https://www.uri with spaces.com/path/to/file",
         "www.without-protocol.com/path/to/file",
         "http://www.domain-only-with-slash.com/",
     ]
 
     for uri in wrong_uris:
         with pytest.raises(SourceNotFoundError):
-            await HttpSource(url=uri).fetch()
+            await WebSource(uri=uri).fetch()


### PR DESCRIPTION
# Description
* Renamed `HttpSource` to `WebSource`
* Changed `url` to `uri` in field name, arguments, docstrings
* Changed prefix in `id()` to `web:`
* Introduced `WebDownloadError`