### PR TITLE
fix: Make source errors picklable

### DIFF
--- a/packages/ragbits-document-search/CHANGELOG.md
+++ b/packages/ragbits-document-search/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Remove obsolete ImageDescrber and llm from UnstructuredImageProvider
+- Remove obsolete ImageDescrber and llm from UnstructuredImageProvider (#430)
+- Make SourceError and its subclasses picklable (#435)
 
 ## 0.10.1 (2025-03-19)
 

--- a/packages/ragbits-document-search/CHANGELOG.md
+++ b/packages/ragbits-document-search/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Remove obsolete ImageDescrber and llm from UnstructuredImageProvider (#430)
+- Remove obsolete ImageDescriber and llm from UnstructuredImageProvider (#430)
 - Make SourceError and its subclasses picklable (#435)
 
 ## 0.10.1 (2025-03-19)

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
@@ -1,3 +1,7 @@
+import inspect
+from typing import Any, Self
+
+
 class SourceError(Exception):
     """
     Class for all exceptions raised by the document source.
@@ -6,6 +10,18 @@ class SourceError(Exception):
     def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message
+
+    def __reduce__(self) -> tuple[type[Self], tuple[Any, ...]]:
+        # This __reduce__ method is written in a way that it automatically handles any subclass of SourceError.
+        # It requires the subclass to have an initializer that store the arguments in the instance's state, under the same name.
+        init_params = inspect.signature(self.__class__.__init__).parameters
+
+        args = [
+            self.__getattribute__(param_name)
+            for param_name in list(init_params.keys())[1:]  # Skip 'self'
+        ]
+
+        return self.__class__, tuple(args)
 
 
 class SourceConnectionError(SourceError):
@@ -34,3 +50,5 @@ class WebDownloadError(SourceError):
 
     def __init__(self, url: str, code: int):
         super().__init__(f"Download of {url} failed with code {code}.")
+        self.url = url
+        self.code = code

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
@@ -13,7 +13,8 @@ class SourceError(Exception):
 
     def __reduce__(self) -> tuple[type["SourceError"], tuple[Any, ...]]:
         # This __reduce__ method is written in a way that it automatically handles any subclass of SourceError.
-        # It requires the subclass to have an initializer that store the arguments in the instance's state, under the same name.
+        # It requires the subclass to have an initializer that store the arguments in the instance's state,
+        # under the same name.
         init_params = inspect.signature(self.__class__.__init__).parameters
 
         args = [

--- a/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
+++ b/packages/ragbits-document-search/src/ragbits/document_search/documents/exceptions.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Self
+from typing import Any
 
 
 class SourceError(Exception):
@@ -11,7 +11,7 @@ class SourceError(Exception):
         super().__init__(message)
         self.message = message
 
-    def __reduce__(self) -> tuple[type[Self], tuple[Any, ...]]:
+    def __reduce__(self) -> tuple[type["SourceError"], tuple[Any, ...]]:
         # This __reduce__ method is written in a way that it automatically handles any subclass of SourceError.
         # It requires the subclass to have an initializer that store the arguments in the instance's state, under the same name.
         init_params = inspect.signature(self.__class__.__init__).parameters

--- a/packages/ragbits-document-search/tests/unit/test_document_search.py
+++ b/packages/ragbits-document-search/tests/unit/test_document_search.py
@@ -254,9 +254,9 @@ async def test_document_search_ingest_from_uri_with_wildcard(
         results = await document_search.search(search_query)
 
         # Check that we have the expected number of results
-        assert len(results) == len(
-            expected_contents
-        ), f"Expected {len(expected_contents)} result(s) but got {len(results)}"
+        assert len(results) == len(expected_contents), (
+            f"Expected {len(expected_contents)} result(s) but got {len(results)}"
+        )
 
         # Verify each result is a TextElement
         assert all(isinstance(result, TextElement) for result in results)

--- a/packages/ragbits-document-search/tests/unit/test_document_search.py
+++ b/packages/ragbits-document-search/tests/unit/test_document_search.py
@@ -254,9 +254,9 @@ async def test_document_search_ingest_from_uri_with_wildcard(
         results = await document_search.search(search_query)
 
         # Check that we have the expected number of results
-        assert len(results) == len(expected_contents), (
-            f"Expected {len(expected_contents)} result(s) but got {len(results)}"
-        )
+        assert len(results) == len(
+            expected_contents
+        ), f"Expected {len(expected_contents)} result(s) but got {len(results)}"
 
         # Verify each result is a TextElement
         assert all(isinstance(result, TextElement) for result in results)

--- a/packages/ragbits-document-search/tests/unit/test_source_exceptions.py
+++ b/packages/ragbits-document-search/tests/unit/test_source_exceptions.py
@@ -17,7 +17,7 @@ def test_source_error_init():
 def test_source_error_pickle():
     original = SourceError("Test pickle message")
     pickled = pickle.dumps(original)
-    unpickled = pickle.loads(pickled) # noqa: S301
+    unpickled = pickle.loads(pickled)  # noqa: S301
 
     assert isinstance(unpickled, SourceError)
     assert unpickled.message == "Test pickle message"
@@ -33,7 +33,7 @@ def test_source_connection_error_init():
 def test_source_connection_error_pickle():
     original = SourceConnectionError()
     pickled = pickle.dumps(original)
-    unpickled = pickle.loads(pickled) # noqa: S301
+    unpickled = pickle.loads(pickled)  # noqa: S301
 
     assert isinstance(unpickled, SourceConnectionError)
     assert unpickled.message == "Connection error."
@@ -50,7 +50,7 @@ def test_source_not_found_error_init():
 def test_source_not_found_error_pickle():
     original = SourceNotFoundError("test-source-id")
     pickled = pickle.dumps(original)
-    unpickled = pickle.loads(pickled) # noqa: S301
+    unpickled = pickle.loads(pickled)  # noqa: S301
 
     assert isinstance(unpickled, SourceNotFoundError)
     assert unpickled.source_id == "test-source-id"
@@ -74,7 +74,7 @@ def test_web_download_error_pickle():
     code = 404
     original = WebDownloadError(url, code)
     pickled = pickle.dumps(original)
-    unpickled = pickle.loads(pickled) # noqa: S301
+    unpickled = pickle.loads(pickled)  # noqa: S301
 
     assert isinstance(unpickled, WebDownloadError)
     assert unpickled.url == url

--- a/packages/ragbits-document-search/tests/unit/test_source_exceptions.py
+++ b/packages/ragbits-document-search/tests/unit/test_source_exceptions.py
@@ -1,0 +1,83 @@
+import pickle
+
+from ragbits.document_search.documents.exceptions import (
+    SourceConnectionError,
+    SourceError,
+    SourceNotFoundError,
+    WebDownloadError,
+)
+
+
+def test_source_error_init():
+    error = SourceError("Test error message")
+    assert error.message == "Test error message"
+    assert str(error) == "Test error message"
+
+
+def test_source_error_pickle():
+    original = SourceError("Test pickle message")
+    pickled = pickle.dumps(original)
+    unpickled = pickle.loads(pickled) # noqa: S301
+
+    assert isinstance(unpickled, SourceError)
+    assert unpickled.message == "Test pickle message"
+    assert str(unpickled) == "Test pickle message"
+
+
+def test_source_connection_error_init():
+    error = SourceConnectionError()
+    assert error.message == "Connection error."
+    assert str(error) == "Connection error."
+
+
+def test_source_connection_error_pickle():
+    original = SourceConnectionError()
+    pickled = pickle.dumps(original)
+    unpickled = pickle.loads(pickled) # noqa: S301
+
+    assert isinstance(unpickled, SourceConnectionError)
+    assert unpickled.message == "Connection error."
+    assert str(unpickled) == "Connection error."
+
+
+def test_source_not_found_error_init():
+    error = SourceNotFoundError("test-source-id")
+    assert error.source_id == "test-source-id"
+    assert error.message == "Source with ID test-source-id not found."
+    assert str(error) == "Source with ID test-source-id not found."
+
+
+def test_source_not_found_error_pickle():
+    original = SourceNotFoundError("test-source-id")
+    pickled = pickle.dumps(original)
+    unpickled = pickle.loads(pickled) # noqa: S301
+
+    assert isinstance(unpickled, SourceNotFoundError)
+    assert unpickled.source_id == "test-source-id"
+    assert unpickled.message == "Source with ID test-source-id not found."
+    assert str(unpickled) == "Source with ID test-source-id not found."
+
+
+def test_web_download_error_init():
+    url = "https://example.com/file.pdf"
+    code = 404
+    error = WebDownloadError(url, code)
+
+    assert error.url == url
+    assert error.code == code
+    assert error.message == f"Download of {url} failed with code {code}."
+    assert str(error) == f"Download of {url} failed with code {code}."
+
+
+def test_web_download_error_pickle():
+    url = "https://example.com/file.pdf"
+    code = 404
+    original = WebDownloadError(url, code)
+    pickled = pickle.dumps(original)
+    unpickled = pickle.loads(pickled) # noqa: S301
+
+    assert isinstance(unpickled, WebDownloadError)
+    assert unpickled.url == url
+    assert unpickled.code == code
+    assert unpickled.message == f"Download of {url} failed with code {code}."
+    assert str(unpickled) == f"Download of {url} failed with code {code}."


### PR DESCRIPTION
Fixes #434 by implementing `__reduce__` method in `SourceError`.