### PR TITLE
fix: union types validation in element enricher

### DIFF
--- a/packages/ragbits-document-search/CHANGELOG.md
+++ b/packages/ragbits-document-search/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
+- fix union types validation in element enricher (#499)
+
 ## 0.13.0 (2025-04-02)
 
 ### Changed
 
 - ragbits-core updated to version v0.13.0
-
 - DocumentSearch.ingest now raises IngestExecutionError when any errors are encountered during ingestion.
 
 ## 0.12.0 (2025-03-25)

--- a/packages/ragbits-document-search/tests/unit/test_element_enrichers.py
+++ b/packages/ragbits-document-search/tests/unit/test_element_enrichers.py
@@ -11,16 +11,27 @@ from ragbits.document_search.ingestion.enrichers.exceptions import EnricherEleme
 from ragbits.document_search.ingestion.enrichers.image import ImageDescriberPrompt, ImageElementEnricher
 
 
-def test_enricher_validates_supported_element_types_passes() -> None:
+def test_enricher_validates_supported_element_types() -> None:
     ImageElementEnricher.validate_element_type(ImageElement)
 
+    with pytest.raises(EnricherElementNotSupportedError):
+        ImageElementEnricher.validate_element_type(TextElement)
 
-def test_enricher_validates_supported_document_types_fails() -> None:
+
+def test_enricher_validates_supported_document_union_types() -> None:
     class CustomElement(Element):
+        @property
+        def text_representation(self) -> str:
+            return ""
+
+    class CustomElementEnricher(ElementEnricher[CustomElement | TextElement]):
         pass
 
+    CustomElementEnricher.validate_element_type(CustomElement)
+    CustomElementEnricher.validate_element_type(TextElement)
+
     with pytest.raises(EnricherElementNotSupportedError):
-        ImageElementEnricher.validate_element_type(CustomElement)  # type: ignore
+        CustomElementEnricher.validate_element_type(ImageElement)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes issue with defining union types for element enrichers. Currently, we could only define an enricher that supported a single element type. In the case of a union, the validator wouldn't work.

```python
SectionElements = SectionWithImageElement | SectionWithTableElement | SectionWithImageAndTableElement

class SectionElementEnricher(ElementEnricher[SectionElements]):
    async def enrich(self, elements: list[SectionElements]) -> list[SectionElements]:
        ...
```