### PR TITLE
#493: feat: sparse embeddings in vector stores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3
+    python: python3.10
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.10
+    python: python3
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v5.0.0

--- a/docs/how-to/vector-stores/hybrid-search.md
+++ b/docs/how-to/vector-stores/hybrid-search.md
@@ -66,10 +66,10 @@ async def hybrid_search(query: str, k: int = 5):
     # Get results from both stores
     dense_results = await dense_store.retrieve(query)
     sparse_results = await sparse_store.retrieve(query)
-    
+
     # Combine results using the chosen strategy
     combined_results = strategy.join([dense_results, sparse_results])
-    
+
     # Return top k results
     return combined_results[:k]
 ```
@@ -88,16 +88,16 @@ class WeightedHybridStrategy(HybridRetrivalStrategy):
     def __init__(self, dense_weight: float = 0.7, sparse_weight: float = 0.3):
         self.dense_weight = dense_weight
         self.sparse_weight = sparse_weight
-    
+
     def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
         if len(results) != 2:
             raise ValueError("WeightedHybridStrategy expects exactly 2 result lists")
-        
+
         dense_results, sparse_results = results
-        
+
         # Create a dictionary to store combined scores
         combined_entries = {}
-        
+
         # Process dense results
         for result in dense_results:
             entry_id = result.entry.id
@@ -107,7 +107,7 @@ class WeightedHybridStrategy(HybridRetrivalStrategy):
                 "score": result.score * self.dense_weight,
                 "subresults": [result]
             }
-        
+
         # Process sparse results
         for result in sparse_results:
             entry_id = result.entry.id
@@ -123,7 +123,7 @@ class WeightedHybridStrategy(HybridRetrivalStrategy):
                     "score": result.score * self.sparse_weight,
                     "subresults": [result]
                 }
-        
+
         # Convert to VectorStoreResult objects and sort
         combined_results = [
             VectorStoreResult(
@@ -134,7 +134,7 @@ class WeightedHybridStrategy(HybridRetrivalStrategy):
             )
             for data in combined_entries.values()
         ]
-        
+
         return sorted(combined_results, key=lambda x: x.score, reverse=True)
 ```
 
@@ -155,7 +155,7 @@ class DynamicWeightedStrategy(HybridRetrivalStrategy):
             # Longer queries likely benefit more from semantic search
             self.dense_weight = 0.7
             self.sparse_weight = 0.3
-    
+
     def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
         # Implementation similar to WeightedHybridStrategy
         # ...

--- a/docs/how-to/vector-stores/hybrid-search.md
+++ b/docs/how-to/vector-stores/hybrid-search.md
@@ -1,0 +1,169 @@
+# Hybrid Search with Vector Stores
+
+Hybrid search combines multiple retrieval methods to improve search quality. This guide explains how to implement hybrid search using Ragbits vector stores.
+
+## What is Hybrid Search?
+
+Hybrid search combines different search approaches, typically:
+- **Dense retrieval**: Using dense embeddings for semantic similarity
+- **Sparse retrieval**: Using sparse embeddings for lexical/keyword matching
+
+By combining these approaches, hybrid search can overcome the limitations of each individual method.
+
+## Implementing Hybrid Search in Ragbits
+
+Ragbits provides several strategies for combining results from different vector stores:
+
+### 1. Set Up Multiple Vector Stores
+
+First, create vector stores with different embedding types:
+
+```python
+from ragbits.core.embeddings.dense import DenseEmbedder
+from ragbits.core.embeddings.sparse import SparseEmbedder
+from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
+from ragbits.core.vector_stores.base import EmbeddingType
+
+# Dense embedder for semantic search
+dense_embedder = DenseEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2")
+dense_store = InMemoryVectorStore(
+    embedder=dense_embedder,
+    embedding_type=EmbeddingType.TEXT
+)
+
+# Sparse embedder for lexical search
+sparse_embedder = SparseEmbedder(vocabulary_size=10000)
+sparse_store = InMemoryVectorStore(
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT
+)
+```
+
+### 2. Choose a Hybrid Retrieval Strategy
+
+Ragbits provides several strategies for combining results:
+
+```python
+from ragbits.core.vector_stores.hybrid_strategies import (
+    OrderedHybridRetrivalStrategy,
+    ReciprocalRankFusion,
+    DistributionBasedScoreFusion
+)
+
+# Choose one of the available strategies
+strategy = ReciprocalRankFusion()
+```
+
+Available strategies:
+- **OrderedHybridRetrivalStrategy**: Orders results by score and deduplicates them
+- **ReciprocalRankFusion**: Combines results based on their ranks rather than raw scores
+- **DistributionBasedScoreFusion**: Normalizes scores based on their distribution before combining
+
+### 3. Perform Hybrid Search
+
+```python
+async def hybrid_search(query: str, k: int = 5):
+    # Get results from both stores
+    dense_results = await dense_store.retrieve(query)
+    sparse_results = await sparse_store.retrieve(query)
+    
+    # Combine results using the chosen strategy
+    combined_results = strategy.join([dense_results, sparse_results])
+    
+    # Return top k results
+    return combined_results[:k]
+```
+
+## Advanced Hybrid Search Techniques
+
+### Weighted Combination
+
+You can implement custom weighting between dense and sparse results:
+
+```python
+from ragbits.core.vector_stores.hybrid_strategies import HybridRetrivalStrategy
+from ragbits.core.vector_stores.base import VectorStoreResult
+
+class WeightedHybridStrategy(HybridRetrivalStrategy):
+    def __init__(self, dense_weight: float = 0.7, sparse_weight: float = 0.3):
+        self.dense_weight = dense_weight
+        self.sparse_weight = sparse_weight
+    
+    def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
+        if len(results) != 2:
+            raise ValueError("WeightedHybridStrategy expects exactly 2 result lists")
+        
+        dense_results, sparse_results = results
+        
+        # Create a dictionary to store combined scores
+        combined_entries = {}
+        
+        # Process dense results
+        for result in dense_results:
+            entry_id = result.entry.id
+            combined_entries[entry_id] = {
+                "entry": result.entry,
+                "vector": result.vector,
+                "score": result.score * self.dense_weight,
+                "subresults": [result]
+            }
+        
+        # Process sparse results
+        for result in sparse_results:
+            entry_id = result.entry.id
+            if entry_id in combined_entries:
+                # Entry already exists from dense results
+                combined_entries[entry_id]["score"] += result.score * self.sparse_weight
+                combined_entries[entry_id]["subresults"].append(result)
+            else:
+                # New entry
+                combined_entries[entry_id] = {
+                    "entry": result.entry,
+                    "vector": result.vector,
+                    "score": result.score * self.sparse_weight,
+                    "subresults": [result]
+                }
+        
+        # Convert to VectorStoreResult objects and sort
+        combined_results = [
+            VectorStoreResult(
+                entry=data["entry"],
+                vector=data["vector"],
+                score=data["score"],
+                subresults=data["subresults"]
+            )
+            for data in combined_entries.values()
+        ]
+        
+        return sorted(combined_results, key=lambda x: x.score, reverse=True)
+```
+
+### Dynamic Weighting
+
+For more advanced scenarios, you can implement dynamic weighting based on query characteristics:
+
+```python
+class DynamicWeightedStrategy(HybridRetrivalStrategy):
+    def __init__(self, query: str):
+        # Analyze query to determine weights
+        query_words = query.split()
+        if len(query_words) <= 2:
+            # Short queries likely benefit more from lexical search
+            self.dense_weight = 0.3
+            self.sparse_weight = 0.7
+        else:
+            # Longer queries likely benefit more from semantic search
+            self.dense_weight = 0.7
+            self.sparse_weight = 0.3
+    
+    def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
+        # Implementation similar to WeightedHybridStrategy
+        # ...
+```
+
+## Best Practices
+
+1. **Experiment with different strategies**: The best hybrid search strategy depends on your specific use case and data.
+2. **Consider query characteristics**: Some queries benefit more from dense retrieval, others from sparse retrieval.
+3. **Evaluate with real queries**: Test your hybrid search with real-world queries to ensure it performs well.
+4. **Monitor performance**: Keep track of which strategy works best for different types of queries.

--- a/docs/how-to/vector-stores/hybrid-search.md
+++ b/docs/how-to/vector-stores/hybrid-search.md
@@ -12,46 +12,46 @@ By combining these approaches, hybrid search can overcome the limitations of eac
 
 ## Implementing Hybrid Search in Ragbits
 
-Ragbits provides several strategies for combining results from different vector stores:
+Ragbits provides a structured approach for combining results from different vector stores:
 
 ### 1. Set Up Multiple Vector Stores
 
 First, create vector stores with different embedding types:
 
 ```python
-from ragbits.core.embeddings.dense import DenseEmbedder
-from ragbits.core.embeddings.sparse import SparseEmbedder
+from ragbits.core.embeddings.openai import OpenAIEmbedder
+from ragbits.core.embeddings.sparse import BM25SparseEmbedder
 from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
 from ragbits.core.vector_stores.base import EmbeddingType
 
-# Dense embedder for semantic search
-dense_embedder = DenseEmbedder(model_name="sentence-transformers/all-MiniLM-L6-v2")
+# Dense embedder for semantic search (using a specific implementation)
+dense_embedder = OpenAIEmbedder(model="text-embedding-3-small")
 dense_store = InMemoryVectorStore(
     embedder=dense_embedder,
     embedding_type=EmbeddingType.TEXT
 )
 
-# Sparse embedder for lexical search
-sparse_embedder = SparseEmbedder(vocabulary_size=10000)
+# Sparse embedder for lexical search (using a specific implementation)
+sparse_embedder = BM25SparseEmbedder()
 sparse_store = InMemoryVectorStore(
     embedder=sparse_embedder,
     embedding_type=EmbeddingType.TEXT
 )
 ```
 
-### 2. Choose a Hybrid Retrieval Strategy
+### 2. Use the HybridSearchVectorStore
 
-Ragbits provides several strategies for combining results:
+Ragbits provides a `HybridSearchVectorStore` class that combines multiple vector stores:
 
 ```python
-from ragbits.core.vector_stores.hybrid_strategies import (
-    OrderedHybridRetrivalStrategy,
-    ReciprocalRankFusion,
-    DistributionBasedScoreFusion
-)
+from ragbits.core.vector_stores.hybrid import HybridSearchVectorStore
+from ragbits.core.vector_stores.hybrid_strategies import ReciprocalRankFusion
 
-# Choose one of the available strategies
-strategy = ReciprocalRankFusion()
+# Create a hybrid search vector store with a fusion strategy
+hybrid_store = HybridSearchVectorStore(
+    dense_store, sparse_store,
+    strategy=ReciprocalRankFusion()
+)
 ```
 
 Available strategies:
@@ -62,68 +62,62 @@ Available strategies:
 ### 3. Perform Hybrid Search
 
 ```python
-async def hybrid_search(query: str, k: int = 5):
-    # Get results from both stores
-    dense_results = await dense_store.retrieve(query)
-    sparse_results = await sparse_store.retrieve(query)
+# Store your documents in both vector stores
+await dense_store.store(entries)
+await sparse_store.store(entries)
 
-    # Combine results using the chosen strategy
-    combined_results = strategy.join([dense_results, sparse_results])
+# Retrieve using the hybrid store
+results = await hybrid_store.retrieve("your search query", options=VectorStoreOptions(k=5))
 
-    # Return top k results
-    return combined_results[:k]
+# Process results
+for result in results:
+    print(f"Score: {result.score}, Text: {result.entry.text}")
 ```
 
 ## Advanced Hybrid Search Techniques
 
-### Weighted Combination
+### Custom Fusion Strategies
 
-You can implement custom weighting between dense and sparse results:
+You can implement custom strategies by extending the `HybridRetrivalStrategy` class:
 
 ```python
 from ragbits.core.vector_stores.hybrid_strategies import HybridRetrivalStrategy
 from ragbits.core.vector_stores.base import VectorStoreResult
 
-class WeightedHybridStrategy(HybridRetrivalStrategy):
-    def __init__(self, dense_weight: float = 0.7, sparse_weight: float = 0.3):
-        self.dense_weight = dense_weight
-        self.sparse_weight = sparse_weight
-
+class WeightedFusionStrategy(HybridRetrivalStrategy):
+    def __init__(self, weights: list[float]):
+        """
+        Initialize with weights for each result list.
+        
+        Args:
+            weights: List of weights corresponding to each vector store's results
+        """
+        self.weights = weights
+        
     def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
-        if len(results) != 2:
-            raise ValueError("WeightedHybridStrategy expects exactly 2 result lists")
-
-        dense_results, sparse_results = results
-
+        if len(results) != len(self.weights):
+            raise ValueError(f"Expected {len(self.weights)} result lists, got {len(results)}")
+            
         # Create a dictionary to store combined scores
         combined_entries = {}
-
-        # Process dense results
-        for result in dense_results:
-            entry_id = result.entry.id
-            combined_entries[entry_id] = {
-                "entry": result.entry,
-                "vector": result.vector,
-                "score": result.score * self.dense_weight,
-                "subresults": [result]
-            }
-
-        # Process sparse results
-        for result in sparse_results:
-            entry_id = result.entry.id
-            if entry_id in combined_entries:
-                # Entry already exists from dense results
-                combined_entries[entry_id]["score"] += result.score * self.sparse_weight
-                combined_entries[entry_id]["subresults"].append(result)
-            else:
-                # New entry
-                combined_entries[entry_id] = {
-                    "entry": result.entry,
-                    "vector": result.vector,
-                    "score": result.score * self.sparse_weight,
-                    "subresults": [result]
-                }
-
+        
+        # Process results from each store with its corresponding weight
+        for result_list, weight in zip(results, self.weights):
+            for result in result_list:
+                entry_id = result.entry.id
+                if entry_id in combined_entries:
+                    # Entry already exists, update score
+                    combined_entries[entry_id]["score"] += result.score * weight
+                    combined_entries[entry_id]["subresults"].append(result)
+                else:
+                    # New entry
+                    combined_entries[entry_id] = {
+                        "entry": result.entry,
+                        "vector": result.vector,
+                        "score": result.score * weight,
+                        "subresults": [result]
+                    }
+        
         # Convert to VectorStoreResult objects and sort
         combined_results = [
             VectorStoreResult(
@@ -134,31 +128,8 @@ class WeightedHybridStrategy(HybridRetrivalStrategy):
             )
             for data in combined_entries.values()
         ]
-
+        
         return sorted(combined_results, key=lambda x: x.score, reverse=True)
-```
-
-### Dynamic Weighting
-
-For more advanced scenarios, you can implement dynamic weighting based on query characteristics:
-
-```python
-class DynamicWeightedStrategy(HybridRetrivalStrategy):
-    def __init__(self, query: str):
-        # Analyze query to determine weights
-        query_words = query.split()
-        if len(query_words) <= 2:
-            # Short queries likely benefit more from lexical search
-            self.dense_weight = 0.3
-            self.sparse_weight = 0.7
-        else:
-            # Longer queries likely benefit more from semantic search
-            self.dense_weight = 0.7
-            self.sparse_weight = 0.3
-
-    def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
-        # Implementation similar to WeightedHybridStrategy
-        # ...
 ```
 
 ## Best Practices
@@ -167,3 +138,4 @@ class DynamicWeightedStrategy(HybridRetrivalStrategy):
 2. **Consider query characteristics**: Some queries benefit more from dense retrieval, others from sparse retrieval.
 3. **Evaluate with real queries**: Test your hybrid search with real-world queries to ensure it performs well.
 4. **Monitor performance**: Keep track of which strategy works best for different types of queries.
+5. **Use the same document IDs**: Ensure documents have the same IDs across different vector stores to enable proper fusion.

--- a/docs/how-to/vector-stores/hybrid-search.md
+++ b/docs/how-to/vector-stores/hybrid-search.md
@@ -88,19 +88,19 @@ class WeightedFusionStrategy(HybridRetrivalStrategy):
     def __init__(self, weights: list[float]):
         """
         Initialize with weights for each result list.
-        
+
         Args:
             weights: List of weights corresponding to each vector store's results
         """
         self.weights = weights
-        
+
     def join(self, results: list[list[VectorStoreResult]]) -> list[VectorStoreResult]:
         if len(results) != len(self.weights):
             raise ValueError(f"Expected {len(self.weights)} result lists, got {len(results)}")
-            
+
         # Create a dictionary to store combined scores
         combined_entries = {}
-        
+
         # Process results from each store with its corresponding weight
         for result_list, weight in zip(results, self.weights):
             for result in result_list:
@@ -117,7 +117,7 @@ class WeightedFusionStrategy(HybridRetrivalStrategy):
                         "score": result.score * weight,
                         "subresults": [result]
                     }
-        
+
         # Convert to VectorStoreResult objects and sort
         combined_results = [
             VectorStoreResult(
@@ -128,7 +128,7 @@ class WeightedFusionStrategy(HybridRetrivalStrategy):
             )
             for data in combined_entries.values()
         ]
-        
+
         return sorted(combined_results, key=lambda x: x.score, reverse=True)
 ```
 

--- a/docs/how-to/vector-stores/sparse-vectors.md
+++ b/docs/how-to/vector-stores/sparse-vectors.md
@@ -28,33 +28,33 @@ class BM25SparseEmbedder(SparseEmbedder):
     def __init__(self):
         # Initialize with your specific parameters
         self.vocabulary = {}  # Map of terms to indices
-        
+
     async def embed_text(self, texts: List[str]) -> List[SparseVector]:
         results = []
         for text in texts:
             # Simple tokenization
             tokens = text.lower().split()
-            
+
             # Count term frequencies
             term_freqs = {}
             for token in tokens:
                 if token not in term_freqs:
                     term_freqs[token] = 0
                 term_freqs[token] += 1
-                
+
                 # Add to vocabulary if new
                 if token not in self.vocabulary:
                     self.vocabulary[token] = len(self.vocabulary)
-            
+
             # Create sparse vector
             indices = []
             values = []
             for term, freq in term_freqs.items():
                 indices.append(self.vocabulary[term])
                 values.append(freq)
-                
+
             results.append(SparseVector(indices=indices, values=values))
-            
+
         return results
 ```
 

--- a/docs/how-to/vector-stores/sparse-vectors.md
+++ b/docs/how-to/vector-stores/sparse-vectors.md
@@ -1,0 +1,114 @@
+# Using Sparse Vectors with Vector Stores
+
+Ragbits supports sparse embeddings through the `SparseVector` and `SparseEmbedder` classes. This guide explains how to use sparse embeddings with vector stores.
+
+## What are Sparse Embeddings?
+
+Unlike dense embeddings (which are represented as arrays of floating-point numbers), sparse embeddings only store non-zero values and their positions. This makes them more efficient for certain types of data and retrieval tasks.
+
+Sparse embeddings are particularly useful for:
+- Lexical search (keyword matching)
+- Representing large vocabularies efficiently
+- Hybrid search approaches combining dense and sparse representations
+
+## Using Sparse Embeddings with Vector Stores
+
+Ragbits vector stores (Qdrant and InMemory) support both dense and sparse embeddings. Here's how to use them:
+
+### 1. Create a Sparse Embedder
+
+First, create a sparse embedder:
+
+```python
+from ragbits.core.embeddings.sparse import SparseEmbedder
+
+# Example sparse embedder configuration
+sparse_embedder = SparseEmbedder(
+    vocabulary_size=10000,
+    tokenizer_name="bert-base-uncased"
+)
+```
+
+### 2. Initialize a Vector Store with the Sparse Embedder
+
+```python
+from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
+from ragbits.core.vector_stores.qdrant import QdrantVectorStore
+from ragbits.core.vector_stores.base import EmbeddingType
+
+# Using InMemoryVectorStore
+in_memory_store = InMemoryVectorStore(
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT
+)
+
+# Or using QdrantVectorStore
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import Distance
+
+qdrant_client = AsyncQdrantClient()
+qdrant_store = QdrantVectorStore(
+    client=qdrant_client,
+    index_name="sparse_vectors",
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT,
+    distance_method=Distance.COSINE
+)
+```
+
+### 3. Store and Retrieve Documents
+
+The API for storing and retrieving documents is the same regardless of whether you're using dense or sparse embeddings:
+
+```python
+import uuid
+from ragbits.core.vector_stores.base import VectorStoreEntry
+
+# Create entries
+entries = [
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="This is a sample document for sparse embedding",
+        metadata={"source": "example"}
+    ),
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="Another document with different keywords",
+        metadata={"source": "example"}
+    )
+]
+
+# Store entries
+await vector_store.store(entries)
+
+# Retrieve similar documents
+results = await vector_store.retrieve("sample document keywords")
+
+# Process results
+for result in results:
+    print(f"Score: {result.score}, Text: {result.entry.text}")
+    
+    # Access the sparse vector if needed
+    if hasattr(result.vector, "indices"):
+        print(f"Sparse vector with {len(result.vector.indices)} non-zero elements")
+```
+
+## Implementation Details
+
+### How Sparse Vectors are Stored
+
+- **InMemoryVectorStore**: Sparse vectors are stored directly in memory as `SparseVector` objects.
+- **QdrantVectorStore**: Since Qdrant doesn't natively support sparse vectors, they are stored in the payload of each point with a special key `_sparse_vector`.
+
+### Similarity Calculation
+
+When comparing vectors:
+- If both vectors are sparse, dot product is used
+- If both vectors are dense, Euclidean distance is used
+- If one vector is sparse and the other is dense, the dense vector is converted to a sparse representation before comparison
+
+## Best Practices
+
+1. **Choose the right embedder**: Sparse embedders work best for lexical search, while dense embedders are better for semantic search.
+2. **Consider hybrid approaches**: For best results, consider using both sparse and dense embeddings together in a hybrid search approach.
+3. **Monitor vector size**: Sparse vectors can be more efficient, but if most values are non-zero, they may be less efficient than dense vectors.

--- a/docs/how-to/vector-stores/sparse-vectors.md
+++ b/docs/how-to/vector-stores/sparse-vectors.md
@@ -87,7 +87,7 @@ results = await vector_store.retrieve("sample document keywords")
 # Process results
 for result in results:
     print(f"Score: {result.score}, Text: {result.entry.text}")
-    
+
     # Access the sparse vector if needed
     if hasattr(result.vector, "indices"):
         print(f"Sparse vector with {len(result.vector.indices)} non-zero elements")

--- a/packages/ragbits-core/docs/how-to/hybrid-search.md
+++ b/packages/ragbits-core/docs/how-to/hybrid-search.md
@@ -106,7 +106,7 @@ results = await hybrid_store.retrieve("AI algorithms for big data")
 for result in results:
     print(f"Text: {result.entry.text}")
     print(f"Score: {result.score}")
-    
+
     # If you want to see the individual scores from each vector store
     if result.subresults:
         for i, subresult in enumerate(result.subresults):

--- a/packages/ragbits-core/docs/how-to/hybrid-search.md
+++ b/packages/ragbits-core/docs/how-to/hybrid-search.md
@@ -1,0 +1,169 @@
+# How to Implement Hybrid Search with Dense and Sparse Embeddings
+
+This guide explains how to implement hybrid search combining both dense and sparse embeddings in Ragbits.
+
+## What is Hybrid Search?
+
+Hybrid search combines multiple search approaches to get the best of both worlds:
+
+- **Dense embeddings**: Good at capturing semantic meaning and contextual relationships
+- **Sparse embeddings**: Excel at lexical matching and keyword preservation
+
+By combining these approaches, you can create more robust search systems that handle both semantic similarity and exact keyword matching.
+
+## Implementing Hybrid Search in Ragbits
+
+Ragbits supports hybrid search through the `HybridSearchVectorStore` class, which can combine results from multiple vector stores.
+
+### Step 1: Create Dense and Sparse Embedders
+
+First, set up both dense and sparse embedders:
+
+```python
+from ragbits.core.embeddings.base import Embedder
+from ragbits.core.embeddings.sparse import SparseEmbedder
+
+# Dense embedder (example using a pre-configured embedder)
+dense_embedder = Embedder.from_config({
+    "type": "ragbits.core.embeddings.openai.OpenAIEmbedder",
+    "config": {
+        "api_key": "your-api-key",
+        "model": "text-embedding-ada-002"
+    }
+})
+
+# Sparse embedder
+sparse_embedder = SparseEmbedder()
+```
+
+### Step 2: Create Vector Stores for Each Embedder Type
+
+Create separate vector stores for dense and sparse embeddings:
+
+```python
+from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
+from ragbits.core.vector_stores.base import EmbeddingType, VectorStoreOptions
+
+# Vector store for dense embeddings
+dense_store = InMemoryVectorStore(
+    embedder=dense_embedder,
+    embedding_type=EmbeddingType.TEXT,
+    default_options=VectorStoreOptions(k=10)
+)
+
+# Vector store for sparse embeddings
+sparse_store = InMemoryVectorStore(
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT,
+    default_options=VectorStoreOptions(k=10)
+)
+```
+
+### Step 3: Create a Hybrid Search Vector Store
+
+Combine the vector stores using `HybridSearchVectorStore`:
+
+```python
+from ragbits.core.vector_stores.hybrid import HybridSearchVectorStore
+
+hybrid_store = HybridSearchVectorStore(
+    stores=[dense_store, sparse_store],
+    weights=[0.7, 0.3]  # Weights for each store (must sum to 1.0)
+)
+```
+
+### Step 4: Store and Retrieve Entries
+
+Store your entries in both vector stores and then query using the hybrid store:
+
+```python
+import uuid
+from ragbits.core.vector_stores.base import VectorStoreEntry
+
+# Create entries
+entries = [
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="This is a sample document about artificial intelligence",
+        metadata={"category": "AI"}
+    ),
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="Machine learning algorithms can process large datasets",
+        metadata={"category": "ML"}
+    )
+]
+
+# Store entries in both vector stores
+await dense_store.store(entries)
+await sparse_store.store(entries)
+
+# Retrieve similar entries using hybrid search
+results = await hybrid_store.retrieve("AI algorithms for big data")
+
+# Access results
+for result in results:
+    print(f"Text: {result.entry.text}")
+    print(f"Score: {result.score}")
+    print(f"Vector type: {type(result.vector).__name__}")
+```
+
+## Fine-tuning Hybrid Search
+
+You can adjust the weights of each vector store to optimize for your specific use case:
+
+- Higher weight for dense store: Better semantic understanding but might miss exact keyword matches
+- Higher weight for sparse store: Better keyword matching but might miss semantically related content
+- Equal weights: Balanced approach
+
+Experiment with different weights to find the optimal configuration for your data and queries.
+
+## Advanced Hybrid Search Techniques
+
+### Reranking
+
+For more sophisticated hybrid search, you can implement a reranking step:
+
+```python
+from ragbits.core.vector_stores.base import VectorStoreResult
+
+async def rerank_results(query: str, results: list[VectorStoreResult]) -> list[VectorStoreResult]:
+    # Custom reranking logic
+    # This could involve additional scoring, filtering, or combining scores in a more complex way
+    return sorted(results, key=lambda r: r.score, reverse=True)
+
+# Use in your search pipeline
+raw_results = await hybrid_store.retrieve("your query")
+final_results = await rerank_results("your query", raw_results)
+```
+
+### Query Expansion
+
+You can also implement query expansion to improve search results:
+
+```python
+async def expand_query(query: str) -> list[str]:
+    # Generate variations of the query
+    return [query, f"about {query}", f"{query} explanation"]
+
+expanded_queries = await expand_query("artificial intelligence")
+all_results = []
+
+for expanded_query in expanded_queries:
+    results = await hybrid_store.retrieve(expanded_query)
+    all_results.extend(results)
+
+# Deduplicate and rerank
+# ...
+```
+
+## Performance Considerations
+
+- Hybrid search requires multiple embedding operations and searches, which can increase latency
+- Consider caching embeddings for frequently used queries
+- For large-scale applications, you might need to optimize the vector stores for performance
+
+## Next Steps
+
+- Explore [Sparse Vectors with Vector Stores](sparse-vectors-with-vector-stores.md) for more details on sparse embeddings
+- Learn about [Vector Store Configuration](vector-store-configuration.md) to optimize your vector stores

--- a/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
+++ b/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
@@ -1,0 +1,106 @@
+# How to Use Sparse Embeddings with Vector Stores
+
+This guide explains how to use sparse embeddings with Ragbits vector stores.
+
+## What are Sparse Embeddings?
+
+Sparse embeddings are vector representations where most of the values are zero. They are efficient for representing high-dimensional data where only a few dimensions have non-zero values. In contrast to dense embeddings (which are arrays of floating-point numbers), sparse embeddings store only the indices and values of non-zero elements.
+
+Sparse embeddings are particularly useful for:
+- Lexical search (keyword matching)
+- Representing large vocabularies efficiently
+- Complementing dense embeddings in hybrid search approaches
+
+## Using Sparse Embeddings in Ragbits
+
+Ragbits supports sparse embeddings through the `SparseVector` class and vector stores that can handle both dense and sparse embeddings.
+
+### Step 1: Create a Sparse Embedder
+
+First, you need an embedder that produces sparse vectors:
+
+```python
+from ragbits.core.embeddings.sparse import SparseEmbedder, SparseVector
+
+# Example of a simple sparse embedder
+sparse_embedder = SparseEmbedder()
+```
+
+### Step 2: Initialize a Vector Store with the Sparse Embedder
+
+You can use any of the supported vector stores with sparse embeddings:
+
+```python
+from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
+from ragbits.core.vector_stores.qdrant import QdrantVectorStore
+from ragbits.core.vector_stores.base import EmbeddingType
+
+# Using InMemoryVectorStore with sparse embeddings
+vector_store = InMemoryVectorStore(
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT
+)
+
+# Or using QdrantVectorStore with sparse embeddings
+from qdrant_client import AsyncQdrantClient
+qdrant_client = AsyncQdrantClient(location=":memory:")
+qdrant_store = QdrantVectorStore(
+    client=qdrant_client,
+    index_name="sparse_vectors",
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT
+)
+```
+
+### Step 3: Store and Retrieve Entries
+
+The process for storing and retrieving entries is the same as with dense embeddings:
+
+```python
+import uuid
+from ragbits.core.vector_stores.base import VectorStoreEntry
+
+# Create entries
+entries = [
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="This is a sample document about artificial intelligence",
+        metadata={"category": "AI"}
+    ),
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="Sparse vectors are efficient for keyword matching",
+        metadata={"category": "NLP"}
+    )
+]
+
+# Store entries
+await vector_store.store(entries)
+
+# Retrieve similar entries
+results = await vector_store.retrieve("artificial intelligence")
+
+# Access results
+for result in results:
+    print(f"Text: {result.entry.text}")
+    print(f"Score: {result.score}")
+    print(f"Vector type: {type(result.vector).__name__}")
+    if isinstance(result.vector, SparseVector):
+        print(f"Non-zero elements: {len(result.vector.indices)}")
+```
+
+## Performance Considerations
+
+- Sparse vectors are more efficient for storage when the dimensionality is high but most values are zero
+- Similarity calculations with sparse vectors can be faster than with dense vectors of the same dimensionality
+- For optimal performance with Qdrant, consider using a hybrid approach where both sparse and dense vectors are stored
+
+## Limitations
+
+- Not all vector databases natively support sparse vectors; Ragbits implements workarounds for those cases
+- Some advanced vector operations may not be available for sparse vectors
+- Performance may vary depending on the specific vector store implementation
+
+## Next Steps
+
+For more advanced use cases, check out the guide on [Hybrid Search with Dense and Sparse Embeddings](hybrid-search.md).

--- a/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
+++ b/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
@@ -20,10 +20,10 @@ Ragbits supports sparse embeddings through the `SparseVector` class and vector s
 First, you need an embedder that produces sparse vectors:
 
 ```python
-from ragbits.core.embeddings.sparse import SparseEmbedder, SparseVector
+from ragbits.core.embeddings.sparse import BM25Embedder, SparseVector
 
-# Example of a simple sparse embedder
-sparse_embedder = SparseEmbedder()
+# Create a sparse embedder implementation
+sparse_embedder = BM25Embedder()
 ```
 
 ### Step 2: Initialize a Vector Store with the Sparse Embedder
@@ -97,7 +97,6 @@ for result in results:
 
 ## Limitations
 
-- Not all vector databases natively support sparse vectors; Ragbits implements workarounds for those cases
 - Some advanced vector operations may not be available for sparse vectors
 - Performance may vary depending on the specific vector store implementation
 

--- a/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
+++ b/packages/ragbits-core/docs/how-to/sparse-vectors-with-vector-stores.md
@@ -1,20 +1,20 @@
-# Using Sparse Vectors with Vector Stores
+# How to Use Sparse Vectors with Vector Stores
 
 This guide explains how to use sparse embeddings with vector stores in Ragbits.
 
-## What are Sparse Vectors?
+## What are Sparse Embeddings?
 
-Sparse vectors are embeddings where most elements are zero. They're particularly useful for:
+Sparse embeddings are vector representations where most elements are zero. Unlike dense embeddings (which have values in all dimensions), sparse embeddings:
 
-- **Lexical search**: Capturing exact keyword matches
-- **Interpretability**: Each dimension often corresponds to a specific term
-- **Efficiency**: Only non-zero elements need to be stored
+- Explicitly represent the presence of specific tokens/words
+- Excel at lexical matching and keyword preservation
+- Are typically high-dimensional but efficient to store due to sparsity
 
-Unlike dense vectors (where all dimensions have values), sparse vectors excel at preserving exact term matches, making them complementary to dense vectors in search applications.
+Common sparse embedding techniques include BM25, TF-IDF, and SPLADE.
 
-## Using Sparse Embeddings in Ragbits
+## Sparse Embeddings in Ragbits
 
-Ragbits supports sparse embeddings through the `BM25Embedder` class, which implements a popular sparse embedding algorithm.
+Ragbits provides built-in support for sparse embeddings through the `SparseVector` class and embedders like `BM25Embedder`.
 
 ### Creating a Sparse Embedder
 
@@ -23,80 +23,112 @@ from ragbits.core.embeddings.sparse import BM25Embedder
 
 # Create a BM25 sparse embedder
 sparse_embedder = BM25Embedder()
+
+# Generate sparse embeddings for a text
+text = "This is a sample document about artificial intelligence"
+sparse_vector = await sparse_embedder.embed_text(text)
+
+# The result is a SparseVector object
+print(f"Indices: {sparse_vector.indices}")
+print(f"Values: {sparse_vector.values}")
 ```
 
-### Using Sparse Embeddings with Vector Stores
+## Using Sparse Embeddings with Vector Stores
 
-Ragbits vector stores support sparse embeddings. Here's how to use them:
+Ragbits vector stores support sparse embeddings, allowing you to store and retrieve documents using sparse representations.
+
+### In-Memory Vector Store with Sparse Embeddings
 
 ```python
 from ragbits.core.vector_stores.in_memory import InMemoryVectorStore
-from ragbits.core.vector_stores.base import EmbeddingType, VectorStoreOptions
+from ragbits.core.vector_stores.base import EmbeddingType, VectorStoreOptions, VectorStoreEntry
 import uuid
 
-# Create a vector store with sparse embedder
+# Create an in-memory vector store with a sparse embedder
 vector_store = InMemoryVectorStore(
     embedder=sparse_embedder,
     embedding_type=EmbeddingType.TEXT,
-    default_options=VectorStoreOptions(k=5)
+    default_options=VectorStoreOptions(k=10)
 )
 
-# Create and store entries
-from ragbits.core.vector_stores.base import VectorStoreEntry
-
+# Create entries
 entries = [
+    VectorStoreEntry(
+        id=uuid.uuid4(),
+        text="This is a sample document about artificial intelligence",
+        metadata={"category": "AI"}
+    ),
     VectorStoreEntry(
         id=uuid.uuid4(),
         text="Machine learning algorithms can process large datasets",
         metadata={"category": "ML"}
-    ),
-    VectorStoreEntry(
-        id=uuid.uuid4(),
-        text="Natural language processing helps computers understand human language",
-        metadata={"category": "NLP"}
     )
 ]
 
 # Store entries
 await vector_store.store(entries)
 
-# Retrieve entries using sparse embeddings
-results = await vector_store.retrieve("language processing algorithms")
+# Retrieve similar entries
+results = await vector_store.retrieve("AI algorithms")
 
-# Process results
+# Access results
 for result in results:
     print(f"Text: {result.entry.text}")
     print(f"Score: {result.score}")
-    print(f"Metadata: {result.entry.metadata}")
-    print("---")
 ```
 
-## Supported Vector Stores
+### Qdrant Vector Store with Sparse Embeddings
 
-The following vector stores in Ragbits support sparse embeddings:
+Qdrant also supports sparse vectors:
 
-- **InMemoryVectorStore**: For in-memory storage and retrieval
-- **QdrantVectorStore**: For persistent storage using Qdrant
+```python
+from ragbits.core.vector_stores.qdrant import QdrantVectorStore
 
-## When to Use Sparse Embeddings
+# Create a Qdrant vector store with a sparse embedder
+qdrant_store = QdrantVectorStore(
+    embedder=sparse_embedder,
+    embedding_type=EmbeddingType.TEXT,
+    default_options=VectorStoreOptions(k=10),
+    collection_name="sparse_docs",
+    url="http://localhost:6333"
+)
 
-Sparse embeddings are particularly useful when:
+# Store and retrieve entries as with the in-memory store
+await qdrant_store.store(entries)
+results = await qdrant_store.retrieve("AI algorithms")
+```
 
-1. **Exact keyword matching is important**: When you need to find documents containing specific terms
-2. **Interpretability matters**: When you need to understand why certain results were returned
-3. **As part of hybrid search**: Combined with dense embeddings for better overall results
+## Advantages of Sparse Vectors in Search
 
-## Combining with Dense Embeddings (Hybrid Search)
+Sparse vectors offer several advantages for certain search scenarios:
 
-For the best results, consider using both sparse and dense embeddings together in a hybrid approach. See the [Hybrid Search guide](hybrid-search.md) for details.
+1. **Exact Keyword Matching**: Sparse vectors excel at finding documents containing specific query terms
+2. **Interpretability**: The non-zero dimensions in sparse vectors often correspond to specific words
+3. **Out-of-Vocabulary Handling**: Sparse vectors can handle terms not seen during training
+
+## When to Use Sparse vs. Dense Embeddings
+
+- **Use sparse embeddings when**:
+  - Exact keyword matching is important
+  - You need high interpretability
+  - The domain contains specialized terminology
+
+- **Use dense embeddings when**:
+  - Semantic understanding is more important than exact matches
+  - You need to capture contextual relationships
+  - The query might use different words than the documents
+
+- **Use hybrid search when**:
+  - You want the benefits of both approaches
+  - Your use case requires both semantic and lexical matching
 
 ## Performance Considerations
 
-- Sparse vectors can be more memory-efficient for storage but may require specialized indexing
-- The BM25 algorithm needs to build a vocabulary from your corpus, which requires an initial processing step
-- For very large datasets, consider using a vector database that natively supports sparse vectors
+- Sparse vectors are typically high-dimensional but storage-efficient due to sparsity
+- Some vector stores optimize sparse vector storage and retrieval
+- Consider the trade-offs between search quality and performance for your specific use case
 
 ## Next Steps
 
-- Explore [Hybrid Search with Vector Stores](hybrid-search.md) to combine sparse and dense embeddings
-- Learn about different embedding models available in Ragbits
+- Explore [Hybrid Search with Dense and Sparse Embeddings](hybrid-search.md) to combine both approaches
+- Learn about different sparse embedding techniques beyond BM25

--- a/packages/ragbits-core/src/ragbits/core/vector_stores/base.py
+++ b/packages/ragbits-core/src/ragbits/core/vector_stores/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import ClassVar, TypeVar
+from typing import ClassVar, TypeVar, Union
 from uuid import UUID
 
 import pydantic
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from typing_extensions import Self
 
 from ragbits.core import vector_stores
+from ragbits.core.embeddings.sparse import SparseVector
 from ragbits.core.embeddings.base import Embedder
 from ragbits.core.options import Options
 from ragbits.core.utils.config_handling import ConfigurableComponent, ObjectConstructionConfig
@@ -52,7 +53,7 @@ class VectorStoreResult(BaseModel):
     """
 
     entry: VectorStoreEntry
-    vector: list[float]
+    vector: Union[list[float], SparseVector]
     score: float
 
     # If the results were created by combining multiple results, this field will contain the subresults.

--- a/packages/ragbits-core/src/ragbits/core/vector_stores/base.py
+++ b/packages/ragbits-core/src/ragbits/core/vector_stores/base.py
@@ -176,7 +176,7 @@ class VectorStoreWithExternalEmbedder(VectorStore[VectorStoreOptionsT]):
         if self._embedding_type == EmbeddingType.IMAGE and not self._embedder.image_support():
             raise ValueError("Embedder does not support image embeddings")
 
-    async def _create_embeddings(self, entries: list[VectorStoreEntry]) -> dict[UUID, list[float]]:
+    async def _create_embeddings(self, entries: list[VectorStoreEntry]) -> dict[UUID, Union[list[float], SparseVector]]:
         """
         Create embeddings for the given entry, using the provided embedder and embedding type.
 

--- a/packages/ragbits-core/src/ragbits/core/vector_stores/in_memory.py
+++ b/packages/ragbits-core/src/ragbits/core/vector_stores/in_memory.py
@@ -104,7 +104,7 @@ class InMemoryVectorStore(VectorStoreWithExternalEmbedder[VectorStoreOptions]):
                 else:
                     # Both are dense vectors
                     score = float(np.linalg.norm(np.array(vector) - np.array(query_vector))) * -1
-                
+
                 result = VectorStoreResult(entry=self._entries[entry_id], vector=vector, score=score)
                 if merged_options.score_threshold is None or result.score >= merged_options.score_threshold:
                     results.append(result)

--- a/packages/ragbits-core/src/ragbits/core/vector_stores/qdrant.py
+++ b/packages/ragbits-core/src/ragbits/core/vector_stores/qdrant.py
@@ -155,10 +155,10 @@ class QdrantVectorStore(VectorStoreWithExternalEmbedder[VectorStoreOptions]):
             for entry in entries:
                 if entry.id not in embeddings:
                     continue
-                
+
                 vector = embeddings[entry.id]
                 payload = entry.model_dump(exclude_none=True)
-                
+
                 if isinstance(vector, SparseVector):
                     # Store sparse vector in payload for Qdrant
                     payload["_sparse_vector"] = vector.model_dump()
@@ -229,7 +229,7 @@ class QdrantVectorStore(VectorStoreWithExternalEmbedder[VectorStoreOptions]):
             outputs.results = []
             for point in query_results.points:
                 entry = VectorStoreEntry.model_validate(point.payload)
-                
+
                 # Check if this point has a sparse vector stored in payload
                 if "_sparse_vector" in point.payload:
                     sparse_data = point.payload["_sparse_vector"]


### PR DESCRIPTION
## #493: feat: sparse embeddings in vector stores

### Description
Currently, Ragbits supports sparse embeddings (via the `SparseVector` and `SparseEmbedder` classes) but none of our vector stores supports this.

1. Change the typing of `VectorStoreResult` to accept `SparseVector` (should now be `list[float] | SparseVector)
2. Add support for sparse embeddings to Qdrant and in_memory vector stores. They should be able to take `Embedder` or `SparseEmbedder` and then return the vector as `list[float]` or `SparseVector` (depending ont he type of embedder).
3. Write HOW-TO documentation on using sparse vectors with vector stores
4. Update the HOW-TO documentation on hybrid search - resolve both the TODO comments that reference sparse vectors.