### PR TITLE
feat: #408 - list of references

### DIFF
--- a/ui/src/core/components/ChatMessage.tsx
+++ b/ui/src/core/components/ChatMessage.tsx
@@ -95,7 +95,7 @@ const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
                       {references.map((reference, index) => (
                         <li key={index}>
                           <a
-                            href={reference.content}
+                            href={reference.url}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="hover:underline"

--- a/ui/src/core/components/ChatMessage.tsx
+++ b/ui/src/core/components/ChatMessage.tsx
@@ -20,7 +20,7 @@ export type ChatMessageProps = {
 const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
   (
     {
-      chatMessage: { content, role },
+      chatMessage: { content, role, references },
       onOpenFeedbackForm,
       classNames,
       likeForm,
@@ -89,6 +89,24 @@ const ChatMessage = forwardRef<HTMLDivElement, ChatMessageProps>(
                 >
                   {content}
                 </Markdown>
+                {references && references.length > 0 && (
+                  <div className="text-xs">
+                    <ul className="list-disc pl-4">
+                      {references.map((reference, index) => (
+                        <li key={index}>
+                          <a
+                            href={reference.content}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:underline"
+                          >
+                            {reference.title}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 <div className="mt-2 flex items-center gap-2">
                   <DelayedTooltip content="Copy" placement="bottom">
                     <Button


### PR DESCRIPTION
Below screenshots for light and dark mode how it looks like

<img width="599" alt="image" src="https://github.com/user-attachments/assets/5d501c94-108f-4692-b469-a896aa53037c" />
<img width="602" alt="image" src="https://github.com/user-attachments/assets/faee9096-5933-4041-a175-f0d01bec7276" />
