### PR TITLE
feat: extend evaluate interface

### DIFF
--- a/packages/ragbits-evaluate/src/ragbits/evaluate/dataloaders/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/dataloaders/document_search.py
@@ -16,18 +16,29 @@ class DocumentSearchDataLoader(DataLoader[DocumentSearchData]):
     and contain the following features: "question, "passages".
     """
 
-    def __init__(self, source: Source, question_key: str = "question", passages_key: str = "passages") -> None:
+    def __init__(
+        self,
+        source: Source,
+        question_key: str = "question",
+        document_ids_key: str = "document_ids",
+        passages_key: str = "passages",
+        page_numbers_key: str = "page_numbers",
+    ) -> None:
         """
         Initialize the document search data loader.
 
         Args:
             source: The source to load the data from.
             question_key: The dataset column name that contains the question.
+            document_ids_key: The dataset column name that contains the document ids. Document ids are optional.
             passages_key: The dataset column name that contains the passages. Passages are optional.
+            page_numbers_key: The dataset column name that contains the page numbers. Page numbers are optional.
         """
         super().__init__(source)
         self.question_key = question_key
+        self.document_ids_key = document_ids_key
         self.passages_key = passages_key
+        self.page_numbers_key = page_numbers_key
 
     async def load(self) -> Iterable[DocumentSearchData]:
         """
@@ -54,7 +65,9 @@ class DocumentSearchDataLoader(DataLoader[DocumentSearchData]):
         return [
             DocumentSearchData(
                 question=data.get(self.question_key),
+                reference_document_ids=data.get(self.document_ids_key),
                 reference_passages=data.get(self.passages_key),
+                reference_page_numbers=data.get(self.page_numbers_key),
             )
             for data in dataset
         ]

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/dataloaders/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/dataloaders/document_search.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 from datasets import load_dataset
 
+from ragbits.core.sources.base import Source
 from ragbits.evaluate.dataloaders.base import DataLoader
 from ragbits.evaluate.dataloaders.exceptions import DataLoaderIncorrectFormatDataError
 from ragbits.evaluate.pipelines.document_search import DocumentSearchData
@@ -14,6 +15,19 @@ class DocumentSearchDataLoader(DataLoader[DocumentSearchData]):
     The source used for this data loader should point to a file that can be loaded by [Hugging Face](https://huggingface.co/docs/datasets/loading#local-and-remote-files)
     and contain the following features: "question, "passages".
     """
+
+    def __init__(self, source: Source, question_key: str = "question", passages_key: str = "passages") -> None:
+        """
+        Initialize the document search data loader.
+
+        Args:
+            source: The source to load the data from.
+            question_key: The dataset column name that contains the question.
+            passages_key: The dataset column name that contains the passages. Passages are optional.
+        """
+        super().__init__(source)
+        self.question_key = question_key
+        self.passages_key = passages_key
 
     async def load(self) -> Iterable[DocumentSearchData]:
         """
@@ -28,18 +42,19 @@ class DocumentSearchDataLoader(DataLoader[DocumentSearchData]):
         data_path = await self.source.fetch()
         dataset = load_dataset(
             path=str(data_path.parent),
-            split=data_path.stem,
+            split="train",
+            data_files={"train": str(data_path.name)},
         )
-        if "question" not in dataset.features or "passages" not in dataset.features:
+        if self.question_key not in dataset.features:
             raise DataLoaderIncorrectFormatDataError(
-                required_features=["question", "passages"],
+                required_features=[self.question_key],
                 data_path=data_path,
             )
 
         return [
             DocumentSearchData(
-                question=data["question"],
-                reference_passages=data["passages"],
+                question=data.get(self.question_key),
+                reference_passages=data.get(self.passages_key),
             )
             for data in dataset
         ]

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/metrics/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/metrics/document_search.py
@@ -58,7 +58,14 @@ class DocumentSearchMetric(Metric[DocumentSearchResult], ABC):
         """
         return self.metric.aggregate(
             [
-                self.metric(result.predicted_passages, result.reference_passages)
+                self.metric(
+                    [
+                        element.text_representation
+                        for element in result.predicted_elements
+                        if element.text_representation
+                    ],
+                    result.reference_passages,
+                )
                 for result in results
                 if result.reference_passages is not None
             ]

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/metrics/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/metrics/document_search.py
@@ -57,7 +57,11 @@ class DocumentSearchMetric(Metric[DocumentSearchResult], ABC):
             The computed metric.
         """
         return self.metric.aggregate(
-            [self.metric(result.predicted_passages, result.reference_passages) for result in results]
+            [
+                self.metric(result.predicted_passages, result.reference_passages)
+                for result in results
+                if result.reference_passages is not None
+            ]
         )
 
 

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from uuid import uuid4
 
@@ -7,6 +7,7 @@ from typing_extensions import Self
 
 from ragbits.core.sources.hf import HuggingFaceSource
 from ragbits.document_search import DocumentSearch
+from ragbits.document_search.documents.element import Element
 from ragbits.evaluate.pipelines.base import EvaluationData, EvaluationPipeline, EvaluationResult
 
 
@@ -28,7 +29,7 @@ class DocumentSearchResult(EvaluationResult):
     """
 
     question: str
-    predicted_passages: list[str]
+    predicted_elements: Sequence[Element]
     reference_document_ids: list[str | int] | None = None
     reference_passages: list[str] | None = None
     reference_page_numbers: list[int] | None = None
@@ -96,7 +97,7 @@ class DocumentSearchPipeline(EvaluationPipeline[DocumentSearch, DocumentSearchDa
         return [
             DocumentSearchResult(
                 question=row.question,
-                predicted_passages=[element.text_representation for element in elements if element.text_representation],
+                predicted_elements=elements,
                 reference_document_ids=row.reference_document_ids,
                 reference_passages=row.reference_passages,
                 reference_page_numbers=row.reference_page_numbers,

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
@@ -16,7 +16,9 @@ class DocumentSearchData(EvaluationData):
     """
 
     question: str
-    reference_passages: list[str] | None
+    reference_document_ids: list[str | int] | None = None
+    reference_passages: list[str] | None = None
+    reference_page_numbers: list[int] | None = None
 
 
 @dataclass
@@ -26,8 +28,10 @@ class DocumentSearchResult(EvaluationResult):
     """
 
     question: str
-    reference_passages: list[str] | None
     predicted_passages: list[str]
+    reference_document_ids: list[str | int] | None = None
+    reference_passages: list[str] | None = None
+    reference_page_numbers: list[int] | None = None
 
 
 class DocumentSearchPipeline(EvaluationPipeline[DocumentSearch, DocumentSearchData, DocumentSearchResult]):
@@ -92,8 +96,10 @@ class DocumentSearchPipeline(EvaluationPipeline[DocumentSearch, DocumentSearchDa
         return [
             DocumentSearchResult(
                 question=row.question,
-                reference_passages=row.reference_passages,
                 predicted_passages=[element.text_representation for element in elements if element.text_representation],
+                reference_document_ids=row.reference_document_ids,
+                reference_passages=row.reference_passages,
+                reference_page_numbers=row.reference_page_numbers,
             )
             for row, elements in zip(data, results, strict=False)
         ]

--- a/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
+++ b/packages/ragbits-evaluate/src/ragbits/evaluate/pipelines/document_search.py
@@ -16,7 +16,7 @@ class DocumentSearchData(EvaluationData):
     """
 
     question: str
-    reference_passages: list[str]
+    reference_passages: list[str] | None
 
 
 @dataclass
@@ -26,7 +26,7 @@ class DocumentSearchResult(EvaluationResult):
     """
 
     question: str
-    reference_passages: list[str]
+    reference_passages: list[str] | None
     predicted_passages: list[str]
 
 


### PR DESCRIPTION
This PR:
- adds support for custom column names in a evaluation dataset
- adds reference document ids and page numbers
- fixes issue with custom evaluation dataset file name