### PR TITLE
docs: fix local llms link

### DIFF
--- a/docs/how-to/llms/use_llms.md
+++ b/docs/how-to/llms/use_llms.md
@@ -46,7 +46,7 @@ print(response)
 
 ## Using Local LLMs
 
-For guidance on setting up and using local models in Ragbits, refer to the [Local LLMs Guide](https://ragbits.deepsense.ai/how-to/use_local_llms/).
+For guidance on setting up and using local models in Ragbits, refer to the [Local LLMs Guide](https://ragbits.deepsense.ai/how-to/llms/use_local_llms/).
 
 # Calling LLM Classes with prompts, raw strings and conversations
 


### PR DESCRIPTION
Fix local llms link in docs so it goes to the right page and doesn't 404.