### PR TITLE
fix(prompt/base.py): Proper parsing of dict to json string

### DIFF
--- a/packages/ragbits-core/CHANGELOG.md
+++ b/packages/ragbits-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix issue with improper convertion to json of tool call arguments (#737)
 - Added Google Drive support (#686)
 - Add LLM Usage to LLMResponseWithMetadata (#700)
 - Split usage per model type (#715)

--- a/packages/ragbits-core/src/ragbits/core/prompt/base.py
+++ b/packages/ragbits-core/src/ragbits/core/prompt/base.py
@@ -1,3 +1,4 @@
+import json
 from abc import ABCMeta, abstractmethod
 from typing import Any, Generic
 
@@ -99,7 +100,7 @@ class BasePrompt(metaclass=ABCMeta):
                             "type": "function",
                             "function": {
                                 "name": name,
-                                "arguments": str(arguments),
+                                "arguments": json.dumps(arguments),
                             },
                         }
                     ],

--- a/packages/ragbits-core/tests/unit/prompts/test_prompt.py
+++ b/packages/ragbits-core/tests/unit/prompts/test_prompt.py
@@ -675,7 +675,7 @@ def test_base_prompt_with_parser_add_tool_use_message_no_history():
     assert prompt.chat[0]["tool_calls"][0]["id"] == "tool_123"
     assert prompt.chat[0]["tool_calls"][0]["type"] == "function"
     assert prompt.chat[0]["tool_calls"][0]["function"]["name"] == "test_function"
-    assert prompt.chat[0]["tool_calls"][0]["function"]["arguments"] == "{'param': 'value'}"
+    assert prompt.chat[0]["tool_calls"][0]["function"]["arguments"] == '{"param": "value"}'
 
     assert prompt.chat[1]["role"] == "tool"
     assert prompt.chat[1]["tool_call_id"] == "tool_123"


### PR DESCRIPTION
Previously this was done by str which caused errors during tool use for both anthropic and gemini models.
Minor change but important