### PR TITLE
fix: missing model names in model cost litellm dict

### DIFF
--- a/packages/ragbits-core/CHANGELOG.md
+++ b/packages/ragbits-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix issue with cost calculation for some models (#748)
 - Fix issue with improper convertion to json of tool call arguments (#737)
 - Added Google Drive support (#686)
 - Add LLM Usage to LLMResponseWithMetadata (#700)

--- a/packages/ragbits-core/src/ragbits/core/llms/litellm.py
+++ b/packages/ragbits-core/src/ragbits/core/llms/litellm.py
@@ -116,7 +116,7 @@ class LiteLLM(LLM[LiteLLMOptions]):
         Returns:
             The estimated cost of the LLM call.
         """
-        response_cost = litellm.model_cost[self.model_name]
+        response_cost = litellm.get_model_info(self.model_name)
         response_cost_input = prompt_tokens * response_cost["input_cost_per_token"]
         response_cost_output = completion_tokens * response_cost["output_cost_per_token"]
         return response_cost_input + response_cost_output


### PR DESCRIPTION
When you initialise your llm like this

`model = LiteLLM(model_name="anthropic/claude-3-7-sonnet-20250219", default_options=options)`

you'll get exception on missing keys in `model_cost` litellm's dictionary