### PR TITLE
fix: resolve nightly build authentication and commit failures 

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: develop
+          token: ${{ secrets.GH_TOKEN }}
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v2
@@ -73,10 +75,16 @@ jobs:
           git config user.name "ds-ragbits-robot"
           git config user.email "ds-ragbits-robot@users.noreply.github.com"
           git add packages/*/pyproject.toml
-          git commit -m "chore: update package versions for nightly build ${{ env.NIGHTLY_VERSION }}"
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update package versions for nightly build ${{ env.NIGHTLY_VERSION }}"
+            git push origin develop
+          fi
+
           git tag "${{ env.NIGHTLY_VERSION }}"
           git push origin "${{ env.NIGHTLY_VERSION }}"
-          git push origin develop
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NIGHTLY_VERSION: ${{ needs.check-for-changes.outputs.nightly-version }}


### PR DESCRIPTION
Fixed two critical issues in the nightly build workflow:

1. Added GH_TOKEN to checkout action to enable authenticated git operations
   - Without this, git push commands would fail due to lack of permissions
   - Also added fetch-depth: 0 to ensure full git history is available

2. Added check for changes before committing version updates
   - Prevents commit failures when there are no actual changes
   - Follows the same pattern used in sync-develop-after-release workflow

These changes align the nightly build workflow with the working patterns used in other repository workflows.