### PR TITLE
feat: support pydantic models in tool arguments

### DIFF
--- a/packages/ragbits-agents/CHANGELOG.md
+++ b/packages/ragbits-agents/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- added support for pydantic models as tool arguments
+
 ## 1.6.2 (2026-03-26)
 
 - ragbits-core updated to version v1.6.2

--- a/packages/ragbits-agents/src/ragbits/agents/tool.py
+++ b/packages/ragbits-agents/src/ragbits/agents/tool.py
@@ -3,7 +3,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validate_call
 from typing_extensions import Self
 
 from ragbits.core.llms.base import LLMClientOptionsT
@@ -93,7 +93,7 @@ class Tool:
             name=schema["function"]["name"],
             description=schema["function"]["description"],
             parameters=schema["function"]["parameters"],
-            on_tool_call=callable,
+            on_tool_call=validate_call(callable),
             context_var_name=get_context_variable_name(callable),
         )
 

--- a/packages/ragbits-agents/src/ragbits/agents/tool.py
+++ b/packages/ragbits-agents/src/ragbits/agents/tool.py
@@ -86,6 +86,12 @@ class Tool:
 
         Returns:
             A new Tool instance representing the callable function.
+
+        Note:
+            Validation of the arguments of the callable is strict. Complex nested schemas, union types, or fields
+            that the LLM tends to misformat can raise `pydantic.ValidationError` at call time. If you want to handle
+            that, construct `Tool(...)` directly (bypassing `validate_call`) and handle validation inside `on_tool_call`
+            so you can feed the error back to the LLM as tool output.
         """
         schema = convert_function_to_function_schema(callable)
 

--- a/packages/ragbits-agents/tests/unit/test_tool.py
+++ b/packages/ragbits-agents/tests/unit/test_tool.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+from ragbits.agents.tool import Tool
+
+
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def add_user(user: User, other_argument: int) -> dict[str, str]:
+    """Adds a user to a database"""
+    return {"status": "OK", "user": user}
+
+
+def test_pydantic_model_argument_is_instantiated():
+    """The LLM sends a plain dict; the callable must receive a User instance."""
+    tool = Tool.from_callable(add_user)
+    tool_output = tool.on_tool_call({"name": "user", "age": 10}, 17)
+    assert tool_output["status"] == "OK"
+    assert tool_output["user"].name == "user"

--- a/packages/ragbits-agents/tests/unit/test_tool.py
+++ b/packages/ragbits-agents/tests/unit/test_tool.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import BaseModel
 
 from ragbits.agents.tool import Tool
@@ -8,7 +10,7 @@ class User(BaseModel):
     age: int
 
 
-def add_user(user: User, other_argument: int) -> dict[str, str]:
+def add_user(user: User, other_argument: int) -> dict[str, Any]:
     """Adds a user to a database"""
     return {"status": "OK", "user": user}
 

--- a/packages/ragbits-core/CHANGELOG.md
+++ b/packages/ragbits-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added support for pydantic models in `convert_function_to_function_schema`
+
 ## 1.6.2 (2026-03-26)
 
 ## 1.6.1 (2026-03-19)

--- a/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
+++ b/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
@@ -65,7 +65,7 @@ def _generate_func_documentation(func: Callable[..., Any]) -> dict:
 def convert_function_to_function_schema(func: Callable[..., Any]) -> dict:
     """
     Given a python function, extracts a `FuncSchema` from it, capturing the name, description,
-    parameter descriptions, and other metadata.
+    parameter descriptions, and other metadata. Supports nested pydantic models as function arguments.
 
     Args:
         func: The function to extract the schema from.
@@ -177,6 +177,7 @@ def convert_function_to_function_schema(func: Callable[..., Any]) -> dict:
                 "type": "object",
                 "properties": json_schema.get("properties", {}),
                 "required": json_schema.get("required", []),
+                "$defs": json_schema.get("$defs", {}),
             },
         },
     }

--- a/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
+++ b/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
@@ -62,6 +62,45 @@ def _generate_func_documentation(func: Callable[..., Any]) -> dict:
     }
 
 
+def _build_field(param: inspect.Parameter, ann: Any, description: str | None) -> tuple[Any, Any]:  # noqa: ANN401
+    """Build the (annotation, Field) tuple for a single parameter."""
+    if param.kind == param.VAR_POSITIONAL:
+        # e.g. *args: extend positional args
+        if get_origin(ann) is tuple:
+            # e.g. def foo(*args: tuple[int, ...]) -> treat as List[int]
+            tuple_args = get_args(ann)
+            args_of_tuple_with_ellipsis_length = 2
+            ann = (
+                list[tuple_args[0]]
+                if len(tuple_args) == args_of_tuple_with_ellipsis_length and tuple_args[1] is Ellipsis
+                else list[Any]
+            )
+        else:
+            # If user wrote *args: int, treat as List[int]
+            ann = list[ann]
+        # Default factory to empty list
+        return ann, Field(default_factory=list, description=description)
+
+    if param.kind == param.VAR_KEYWORD:
+        # **kwargs handling
+        if get_origin(ann) is dict:
+            # e.g. def foo(**kwargs: dict[str, int])
+            dict_args = get_args(ann)
+            dict_args_to_check_length = 2
+            ann = dict[dict_args[0], dict_args[1]] if len(dict_args) == dict_args_to_check_length else dict[str, Any]
+        else:
+            # e.g. def foo(**kwargs: int) -> Dict[str, int]
+            ann = dict[str, ann]
+        return ann, Field(default_factory=dict, description=description)
+
+    if param.default == inspect._empty:
+        # Required field
+        return ann, Field(..., description=description)
+
+    # Parameter with a default value
+    return ann, Field(default=param.default, description=description)
+
+
 def convert_function_to_function_schema(func: Callable[..., Any]) -> dict:
     """
     Given a python function, extracts a `FuncSchema` from it, capturing the name, description,
@@ -98,69 +137,9 @@ def convert_function_to_function_schema(func: Callable[..., Any]) -> dict:
 
     for name, param in filtered_params:
         ann = type_hints.get(name, param.annotation)
-        default = param.default
-
-        # If there's no type hint, assume `Any`
         if ann == inspect._empty:
             ann = Any
-
-        # If a docstring param description exists, use it
-        field_description = param_descs.get(name, None)
-
-        # Handle different parameter kinds
-        if param.kind == param.VAR_POSITIONAL:
-            # e.g. *args: extend positional args
-            if get_origin(ann) is tuple:
-                # e.g. def foo(*args: tuple[int, ...]) -> treat as List[int]
-                args_of_tuple = get_args(ann)
-                args_of_tuple_with_ellipsis_length = 2
-                ann = (
-                    list[args_of_tuple[0]]  # type: ignore
-                    if len(args_of_tuple) == args_of_tuple_with_ellipsis_length and args_of_tuple[1] is Ellipsis
-                    else list[Any]
-                )
-            else:
-                # If user wrote *args: int, treat as List[int]
-                ann = list[ann]  # type: ignore
-
-            # Default factory to empty list
-            fields[name] = (
-                ann,
-                Field(default_factory=list, description=field_description),  # type: ignore
-            )
-
-        elif param.kind == param.VAR_KEYWORD:
-            # **kwargs handling
-            if get_origin(ann) is dict:
-                # e.g. def foo(**kwargs: dict[str, int])
-                dict_args = get_args(ann)
-                dict_args_to_check_length = 2
-                ann = (
-                    dict[dict_args[0], dict_args[1]]  # type: ignore
-                    if len(dict_args) == dict_args_to_check_length
-                    else dict[str, Any]
-                )  # type: ignore
-            else:
-                # e.g. def foo(**kwargs: int) -> Dict[str, int]
-                ann = dict[str, ann]  # type: ignore
-
-            fields[name] = (
-                ann,
-                Field(default_factory=dict, description=field_description),  # type: ignore
-            )
-
-        elif default == inspect._empty:
-            # Required field
-            fields[name] = (
-                ann,
-                Field(..., description=field_description),
-            )
-        else:
-            # Parameter with a default value
-            fields[name] = (
-                ann,
-                Field(default=default, description=field_description),
-            )
+        fields[name] = _build_field(param, ann, param_descs.get(name))
 
     # 3. Dynamically build a Pydantic model
     dynamic_model = create_model(f"{func_name}_args", __base__=BaseModel, **fields)

--- a/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
+++ b/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
@@ -168,17 +168,20 @@ def convert_function_to_function_schema(func: Callable[..., Any]) -> dict:
     # 4. Build JSON schema from that model
     json_schema = dynamic_model.model_json_schema()
 
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": json_schema.get("properties", {}),
+        "required": json_schema.get("required", []),
+    }
+    if json_schema.get("$defs"):
+        parameters["$defs"] = json_schema["$defs"]
+
     return {
         "type": "function",
         "function": {
             "name": func_name,
             "description": doc_info["description"] if doc_info else None,
-            "parameters": {
-                "type": "object",
-                "properties": json_schema.get("properties", {}),
-                "required": json_schema.get("required", []),
-                "$defs": json_schema.get("$defs", {}),
-            },
+            "parameters": parameters,
         },
     }
 

--- a/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
+++ b/packages/ragbits-core/src/ragbits/core/utils/function_schema.py
@@ -71,15 +71,15 @@ def _build_field(param: inspect.Parameter, ann: Any, description: str | None) ->
             tuple_args = get_args(ann)
             args_of_tuple_with_ellipsis_length = 2
             ann = (
-                list[tuple_args[0]]
+                list[tuple_args[0]]  # type: ignore
                 if len(tuple_args) == args_of_tuple_with_ellipsis_length and tuple_args[1] is Ellipsis
                 else list[Any]
             )
         else:
             # If user wrote *args: int, treat as List[int]
-            ann = list[ann]
+            ann = list[ann]  # type: ignore
         # Default factory to empty list
-        return ann, Field(default_factory=list, description=description)
+        return ann, Field(default_factory=list, description=description)  # type: ignore
 
     if param.kind == param.VAR_KEYWORD:
         # **kwargs handling
@@ -87,11 +87,15 @@ def _build_field(param: inspect.Parameter, ann: Any, description: str | None) ->
             # e.g. def foo(**kwargs: dict[str, int])
             dict_args = get_args(ann)
             dict_args_to_check_length = 2
-            ann = dict[dict_args[0], dict_args[1]] if len(dict_args) == dict_args_to_check_length else dict[str, Any]
+            ann = (
+                dict[dict_args[0], dict_args[1]]  # type: ignore
+                if len(dict_args) == dict_args_to_check_length
+                else dict[str, Any]
+            )
         else:
             # e.g. def foo(**kwargs: int) -> Dict[str, int]
-            ann = dict[str, ann]
-        return ann, Field(default_factory=dict, description=description)
+            ann = dict[str, ann]  # type: ignore
+        return ann, Field(default_factory=dict, description=description)  # type: ignore
 
     if param.default == inspect._empty:
         # Required field

--- a/packages/ragbits-core/tests/unit/utils/test_function_schema.py
+++ b/packages/ragbits-core/tests/unit/utils/test_function_schema.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 
 import pytest
+from pydantic import BaseModel
 
 from ragbits.agents import AgentRunContext
 from ragbits.core.utils.function_schema import convert_function_to_function_schema, get_context_variable_name
@@ -32,6 +33,16 @@ def get_weather_no_context(location: str) -> str:
     return "{'location': 'San Francisco', 'temperature': 72, 'unit': 'fahrenheit'}"
 
 
+class User(BaseModel):
+    name: str
+    age: int
+
+
+def add_user(user: User) -> dict[str, str]:
+    """Adds a user to a database"""
+    return {"status": f"User {user} added"}
+
+
 @pytest.mark.parametrize("function", [get_weather, get_weather_no_context])
 def test_convert_function_to_function_schema(function: Callable):
     """Test converting function to function schema"""
@@ -51,6 +62,7 @@ def test_convert_function_to_function_schema(function: Callable):
                     }
                 },
                 "required": ["location"],
+                "$defs": {},
             },
         },
     }
@@ -67,3 +79,32 @@ def test_convert_function_to_function_schema(function: Callable):
 def test_get_context_variable_name(function: Callable, expected: str | None):
     """Test getting the context variable name"""
     assert get_context_variable_name(function) == expected
+
+
+def test_pydantic_model_tool_argument():
+    """Test that a tool with a pydantic model argument exposes the model's JSON schema to the LLM."""
+    function_schema = convert_function_to_function_schema(add_user)
+    expected_function_schema = {
+        "type": "function",
+        "function": {
+            "name": "add_user",
+            "description": "Adds a user to a database",
+            "parameters": {
+                "type": "object",
+                "properties": {"user": {"$ref": "#/$defs/User"}},
+                "required": ["user"],
+                "$defs": {
+                    "User": {
+                        "properties": {
+                            "name": {"title": "Name", "type": "string"},
+                            "age": {"title": "Age", "type": "integer"},
+                        },
+                        "required": ["name", "age"],
+                        "title": "User",
+                        "type": "object",
+                    }
+                },
+            },
+        },
+    }
+    assert function_schema == expected_function_schema

--- a/packages/ragbits-core/tests/unit/utils/test_function_schema.py
+++ b/packages/ragbits-core/tests/unit/utils/test_function_schema.py
@@ -62,7 +62,6 @@ def test_convert_function_to_function_schema(function: Callable):
                     }
                 },
                 "required": ["location"],
-                "$defs": {},
             },
         },
     }


### PR DESCRIPTION
Solves https://github.com/deepsense-ai/ragbits/issues/913

Now, we can pass pydantic models as tool arguments. The flow is the following: 
* define a function with pydantic model as argument -
* pass it to agent 
* LLM receives the appropriate JSON schema 
* LLM sends the data in JSON format 
* tool converts that JSON into the pydantic model, so that the callable can run
